### PR TITLE
Add hook command tests, tab completion, and CliError migration

### DIFF
--- a/src/commands/completion.ts
+++ b/src/commands/completion.ts
@@ -3,10 +3,12 @@ import {
   getSubcommands,
   getBranchCommands,
   getShellCommands,
+  getHookNameCommands,
   getCommandFlags,
   getGlobalFlags,
   getCommandDescriptions,
 } from '../lib/commands.ts'
+import { HOOK_NAMES } from '../lib/hooks.ts'
 import * as output from '../lib/output.ts'
 
 /**
@@ -52,6 +54,7 @@ function generateBashCompletion(): string {
   const subcommands = getSubcommands()
   const branchCommands = getBranchCommands()
   const shellCommands = getShellCommands()
+  const hookNameCommands = getHookNameCommands()
   const commandFlags = getCommandFlags()
   const globalFlags = getGlobalFlags()
 
@@ -59,6 +62,7 @@ function generateBashCompletion(): string {
   const branchCommandsPattern = branchCommands.join('|')
   const globalFlagList = globalFlags.join(' ')
   const shellList = SUPPORTED_SHELLS.join(' ')
+  const hookNameList = (HOOK_NAMES as readonly string[]).join(' ')
 
   // Build the per-command flag cases
   const flagCases = Object.entries(commandFlags)
@@ -76,6 +80,20 @@ function generateBashCompletion(): string {
         '  # ' + cmd + ' takes a shell name',
         '  if [[ "${words[1]}" == "' + cmd + '" && $cword -eq 2 ]]; then',
         '    COMPREPLY=($(compgen -W "' + shellList + '" -- "$cur"))',
+        '    return',
+        '  fi',
+      ].join('\n')
+    )
+    .join('')
+
+  // Build hook-name completion blocks
+  const hookBlocks = hookNameCommands
+    .map(cmd =>
+      [
+        '',
+        '  # ' + cmd + ' takes a hook name',
+        '  if [[ "${words[1]}" == "' + cmd + '" && $cword -eq 2 ]]; then',
+        '    COMPREPLY=($(compgen -W "' + hookNameList + '" -- "$cur"))',
         '    return',
         '  fi',
       ].join('\n')
@@ -129,6 +147,7 @@ function generateBashCompletion(): string {
     '      ;;',
     '  esac',
     shellBlocks,
+    hookBlocks,
     '}',
     '',
     'complete -F _port_completions port',
@@ -143,6 +162,7 @@ function generateZshCompletion(): string {
   const subcommands = getSubcommands()
   const branchCommands = getBranchCommands()
   const shellCommands = getShellCommands()
+  const hookNameCommands = getHookNameCommands()
   const commandFlags = getCommandFlags()
   const globalFlags = getGlobalFlags()
 
@@ -150,6 +170,7 @@ function generateZshCompletion(): string {
   const quotedGlobalFlags = globalFlags.map(f => "'" + f + "'").join(' ')
   const branchCommandsPattern = branchCommands.join('|')
   const shellList = SUPPORTED_SHELLS.join(' ')
+  const hookNameList = (HOOK_NAMES as readonly string[]).join(' ')
 
   // Build the per-command flag cases
   const flagCases = Object.entries(commandFlags)
@@ -207,6 +228,18 @@ function generateZshCompletion(): string {
     '    compadd -- ' + shellList,
     '    return',
     '  fi',
+    '',
+    '  # Hook-name-accepting commands: complete with hook names',
+    ...(hookNameCommands.length > 0
+      ? [
+          '  if [[ ' +
+            hookNameCommands.map(c => '"$cmd" == "' + c + '"').join(' || ') +
+            ' ]] && (( CURRENT == 3 )); then',
+          '    compadd -- ' + hookNameList,
+          '    return',
+          '  fi',
+        ]
+      : []),
     '}',
     '',
     'compdef _port port',
@@ -221,6 +254,7 @@ function generateFishCompletion(): string {
   const subcommands = getSubcommands()
   const branchCommands = getBranchCommands()
   const shellCommands = getShellCommands()
+  const hookNameCommands = getHookNameCommands()
   const commandFlags = getCommandFlags()
   const descriptions = getCommandDescriptions()
 
@@ -306,6 +340,18 @@ function generateFishCompletion(): string {
   const shellList = SUPPORTED_SHELLS.join(' ')
   for (const cmd of shellCommands) {
     lines.push("complete -c port -n '__port_using_subcommand " + cmd + "' -a '" + shellList + "'")
+  }
+
+  // Hook-name-accepting commands
+  if (hookNameCommands.length > 0) {
+    const hookNameList = (HOOK_NAMES as readonly string[]).join(' ')
+    lines.push('')
+    lines.push('# Hook name completions for hook-accepting commands')
+    for (const cmd of hookNameCommands) {
+      lines.push(
+        "complete -c port -n '__port_using_subcommand " + cmd + "' -a '" + hookNameList + "'"
+      )
+    }
   }
 
   return lines.join('\n')

--- a/src/commands/hook.test.ts
+++ b/src/commands/hook.test.ts
@@ -1,0 +1,204 @@
+import { beforeEach, describe, expect, test, vi } from 'vitest'
+import { CliError } from '../lib/cli.ts'
+
+const mocks = vi.hoisted(() => ({
+  detectWorktree: vi.fn(),
+  hookExists: vi.fn(),
+  runHook: vi.fn(),
+  header: vi.fn(),
+  newline: vi.fn(),
+  info: vi.fn(),
+  dim: vi.fn(),
+  success: vi.fn(),
+  error: vi.fn(),
+  command: vi.fn((s: string) => s),
+}))
+
+vi.mock('../lib/worktree.ts', () => ({
+  detectWorktree: mocks.detectWorktree,
+}))
+
+vi.mock('../lib/hooks.ts', async importOriginal => {
+  const actual = await importOriginal<typeof import('../lib/hooks.ts')>()
+  return {
+    ...actual,
+    hookExists: mocks.hookExists,
+    runHook: mocks.runHook,
+  }
+})
+
+vi.mock('../lib/output.ts', () => ({
+  header: mocks.header,
+  newline: mocks.newline,
+  info: mocks.info,
+  dim: mocks.dim,
+  success: mocks.success,
+  error: mocks.error,
+  command: mocks.command,
+}))
+
+import { hook } from './hook.ts'
+
+describe('hook command', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mocks.detectWorktree.mockReturnValue({
+      repoRoot: '/repo',
+      worktreePath: '/repo/.port/trees/my-branch',
+      name: 'my-branch',
+      isMainRepo: false,
+    })
+    mocks.hookExists.mockResolvedValue(true)
+    mocks.runHook.mockResolvedValue({ success: true, exitCode: 0 })
+  })
+
+  // -----------------------------------------------------------------------
+  // Worktree detection
+  // -----------------------------------------------------------------------
+
+  test('throws CliError when not in a git repository', async () => {
+    mocks.detectWorktree.mockImplementation(() => {
+      throw new Error('not in git')
+    })
+
+    await expect(hook('post-create', {})).rejects.toBeInstanceOf(CliError)
+    expect(mocks.error).toHaveBeenCalledWith('Not in a git repository')
+  })
+
+  // -----------------------------------------------------------------------
+  // --list flag
+  // -----------------------------------------------------------------------
+
+  test('--list shows configured hooks', async () => {
+    mocks.hookExists.mockResolvedValue(true)
+
+    await hook(undefined, { list: true })
+
+    expect(mocks.header).toHaveBeenCalledWith('Available hooks:')
+    expect(mocks.info).toHaveBeenCalledWith(expect.stringContaining('post-create'))
+    expect(mocks.dim).not.toHaveBeenCalled()
+  })
+
+  test('--list shows unconfigured hooks', async () => {
+    mocks.hookExists.mockResolvedValue(false)
+
+    await hook(undefined, { list: true })
+
+    expect(mocks.header).toHaveBeenCalledWith('Available hooks:')
+    expect(mocks.dim).toHaveBeenCalledWith(expect.stringContaining('post-create'))
+    expect(mocks.dim).toHaveBeenCalledWith(expect.stringContaining('not configured'))
+  })
+
+  test('--list works from main repo (no worktree check)', async () => {
+    mocks.detectWorktree.mockReturnValue({
+      repoRoot: '/repo',
+      worktreePath: '/repo',
+      name: 'main',
+      isMainRepo: true,
+    })
+    mocks.hookExists.mockResolvedValue(true)
+
+    await hook(undefined, { list: true })
+
+    expect(mocks.header).toHaveBeenCalledWith('Available hooks:')
+  })
+
+  // -----------------------------------------------------------------------
+  // Missing hook name
+  // -----------------------------------------------------------------------
+
+  test('throws CliError when no hook name is provided', async () => {
+    await expect(hook(undefined, {})).rejects.toBeInstanceOf(CliError)
+    expect(mocks.error).toHaveBeenCalledWith('Missing hook name')
+    // Should also show available hooks
+    expect(mocks.header).toHaveBeenCalledWith('Available hooks:')
+  })
+
+  // -----------------------------------------------------------------------
+  // Invalid hook name
+  // -----------------------------------------------------------------------
+
+  test('throws CliError for unknown hook name', async () => {
+    await expect(hook('invalid-hook', {})).rejects.toBeInstanceOf(CliError)
+    expect(mocks.error).toHaveBeenCalledWith('Unknown hook "invalid-hook"')
+    // Should also show available hooks
+    expect(mocks.header).toHaveBeenCalledWith('Available hooks:')
+  })
+
+  // -----------------------------------------------------------------------
+  // Must be in a worktree
+  // -----------------------------------------------------------------------
+
+  test('throws CliError when run from main repo', async () => {
+    mocks.detectWorktree.mockReturnValue({
+      repoRoot: '/repo',
+      worktreePath: '/repo',
+      name: 'main',
+      isMainRepo: true,
+    })
+
+    await expect(hook('post-create', {})).rejects.toBeInstanceOf(CliError)
+    expect(mocks.error).toHaveBeenCalledWith(
+      'Must be inside a worktree to run hooks. Use `port enter <branch>` first.'
+    )
+  })
+
+  // -----------------------------------------------------------------------
+  // Hook script not found
+  // -----------------------------------------------------------------------
+
+  test('throws CliError when hook script does not exist', async () => {
+    mocks.hookExists.mockResolvedValue(false)
+
+    await expect(hook('post-create', {})).rejects.toBeInstanceOf(CliError)
+    expect(mocks.error).toHaveBeenCalledWith(
+      'Hook "post-create" is not configured. Create an executable script at .port/hooks/post-create.sh'
+    )
+  })
+
+  // -----------------------------------------------------------------------
+  // Successful hook execution
+  // -----------------------------------------------------------------------
+
+  test('runs hook and reports success', async () => {
+    await hook('post-create', {})
+
+    expect(mocks.info).toHaveBeenCalledWith('Running post-create hook...')
+    expect(mocks.runHook).toHaveBeenCalledWith(
+      '/repo',
+      'post-create',
+      {
+        PORT_ROOT_PATH: '/repo',
+        PORT_WORKTREE_PATH: '/repo/.port/trees/my-branch',
+        PORT_BRANCH: 'my-branch',
+      },
+      'my-branch'
+    )
+    expect(mocks.success).toHaveBeenCalledWith('Hook "post-create" completed')
+  })
+
+  // -----------------------------------------------------------------------
+  // Failed hook execution
+  // -----------------------------------------------------------------------
+
+  test('throws CliError when hook fails with non-zero exit code', async () => {
+    mocks.runHook.mockResolvedValue({ success: false, exitCode: 2 })
+
+    await expect(hook('post-create', {})).rejects.toBeInstanceOf(CliError)
+    expect(mocks.error).toHaveBeenCalledWith('Hook "post-create" failed (exit code 2)')
+    expect(mocks.dim).toHaveBeenCalledWith('See .port/logs/latest.log for details')
+  })
+
+  test('CliError from failed hook carries the hook exit code', async () => {
+    mocks.runHook.mockResolvedValue({ success: false, exitCode: 42 })
+
+    try {
+      await hook('post-create', {})
+      expect.unreachable('should have thrown')
+    } catch (err) {
+      expect(err).toBeInstanceOf(CliError)
+      expect((err as CliError).exitCode).toBe(42)
+      expect((err as CliError).alreadyReported).toBe(true)
+    }
+  })
+})

--- a/src/commands/hook.ts
+++ b/src/commands/hook.ts
@@ -1,6 +1,6 @@
 import { detectWorktree } from '../lib/worktree.ts'
 import { hookExists, runHook, HOOK_NAMES, type HookName } from '../lib/hooks.ts'
-import { failWithError } from '../lib/cli.ts'
+import { CliError, failWithError } from '../lib/cli.ts'
 import * as output from '../lib/output.ts'
 
 /**
@@ -55,7 +55,7 @@ export async function hook(
     output.error('Missing hook name')
     output.newline()
     await listHooks(repoRoot)
-    process.exit(1)
+    throw new CliError('Missing hook name', { exitCode: 1, alreadyReported: true })
   }
 
   // Validate hook name
@@ -63,7 +63,7 @@ export async function hook(
     output.error(`Unknown hook "${hookName}"`)
     output.newline()
     await listHooks(repoRoot)
-    process.exit(1)
+    throw new CliError(`Unknown hook "${hookName}"`, { exitCode: 1, alreadyReported: true })
   }
 
   // Must be in a worktree
@@ -95,7 +95,10 @@ export async function hook(
   if (!result.success) {
     output.error(`Hook "${hookName}" failed (exit code ${result.exitCode})`)
     output.dim('See .port/logs/latest.log for details')
-    process.exit(1)
+    throw new CliError(`Hook "${hookName}" failed (exit code ${result.exitCode})`, {
+      exitCode: result.exitCode,
+      alreadyReported: true,
+    })
   }
 
   output.success(`Hook "${hookName}" completed`)

--- a/src/lib/commands.ts
+++ b/src/lib/commands.ts
@@ -70,6 +70,23 @@ export function getShellCommands(): string[] {
 }
 
 /**
+ * Commands that accept a `[hook-name]` argument (detected by argument name).
+ */
+export function getHookNameCommands(): string[] {
+  const result: string[] = []
+
+  for (const command of program.commands) {
+    const hasHookArg = command.registeredArguments.some(arg => arg.name() === 'hook-name')
+    if (hasHookArg) {
+      result.push(command.name())
+      result.push(...command.aliases())
+    }
+  }
+
+  return result
+}
+
+/**
  * Per-command flags, keyed by command name and alias.
  * Only includes commands that have options beyond the global defaults.
  * Excludes hidden options.


### PR DESCRIPTION
- Add unit tests for port hook command (11 test cases covering validation, worktree detection, execution, and error paths)
- Add hook-name tab completion for bash, zsh, and fish shells
- Migrate process.exit(1) calls to CliError for composability

Closes #27