### PR TITLE
Optional init

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,13 +50,13 @@ Want a guided workflow in the CLI?
 port onboard
 ```
 
-### 1. Initialize Project
+### 1. (Optional) Initialize Project
 
 ```bash
 port init
 ```
 
-This sets up the `.port/` directory structure and checks DNS configuration.
+This scaffolds `.port/config.jsonc`, hooks, and templates. Core worktree commands can run without this step.
 
 ### 2. Configure Project
 

--- a/src/commands/compose.ts
+++ b/src/commands/compose.ts
@@ -1,7 +1,7 @@
 import { existsSync } from 'fs'
 import { join } from 'path'
 import { detectWorktree } from '../lib/worktree.ts'
-import { loadConfig, configExists, getComposeFile } from '../lib/config.ts'
+import { loadConfigOrDefault, getComposeFile, ensurePortRuntimeDir } from '../lib/config.ts'
 import { runCompose, getOverrideRelativePath, getProjectName } from '../lib/compose.ts'
 import * as output from '../lib/output.ts'
 
@@ -25,16 +25,12 @@ export async function compose(args: string[]): Promise<void> {
 
   const { repoRoot, worktreePath, name } = worktreeInfo
 
-  // Check if port is initialized
-  if (!configExists(repoRoot)) {
-    output.error('Port not initialized. Run "port init" first.')
-    process.exit(1)
-  }
+  await ensurePortRuntimeDir(repoRoot)
 
   // Load config
   let config
   try {
-    config = await loadConfig(repoRoot)
+    config = await loadConfigOrDefault(repoRoot)
   } catch (error) {
     output.error(`Failed to load config: ${error}`)
     process.exit(1)

--- a/src/commands/down.test.ts
+++ b/src/commands/down.test.ts
@@ -3,8 +3,8 @@ import { beforeEach, describe, expect, test, vi } from 'vitest'
 const mocks = vi.hoisted(() => ({
   prompt: vi.fn(),
   detectWorktree: vi.fn(),
-  configExists: vi.fn(),
-  loadConfig: vi.fn(),
+  ensurePortRuntimeDir: vi.fn(),
+  loadConfigOrDefault: vi.fn(),
   getComposeFile: vi.fn(),
   unregisterProject: vi.fn(),
   hasRegisteredProjects: vi.fn(),
@@ -35,8 +35,8 @@ vi.mock('../lib/worktree.ts', () => ({
 }))
 
 vi.mock('../lib/config.ts', () => ({
-  configExists: mocks.configExists,
-  loadConfig: mocks.loadConfig,
+  ensurePortRuntimeDir: mocks.ensurePortRuntimeDir,
+  loadConfigOrDefault: mocks.loadConfigOrDefault,
   getComposeFile: mocks.getComposeFile,
 }))
 
@@ -78,8 +78,8 @@ describe('down fallback behavior', () => {
       throw new Error('Not in a git repository')
     })
 
-    mocks.configExists.mockReturnValue(true)
-    mocks.loadConfig.mockResolvedValue({ domain: 'port', compose: 'docker-compose.yml' })
+    mocks.ensurePortRuntimeDir.mockResolvedValue(undefined)
+    mocks.loadConfigOrDefault.mockResolvedValue({ domain: 'port', compose: 'docker-compose.yml' })
     mocks.getComposeFile.mockReturnValue('docker-compose.yml')
 
     mocks.unregisterProject.mockResolvedValue(undefined)
@@ -118,20 +118,19 @@ describe('down fallback behavior', () => {
     expect(mocks.stopTraefik).toHaveBeenCalledTimes(1)
   })
 
-  test('falls back to global Traefik shutdown when repo is not initialized', async () => {
+  test('uses defaults and runs compose down when repo has no config file', async () => {
     mocks.detectWorktree.mockReturnValue({
       repoRoot: '/repo',
       worktreePath: '/repo',
       name: 'main',
       isMainRepo: true,
     })
-    mocks.configExists.mockReturnValue(false)
+    mocks.loadConfigOrDefault.mockResolvedValue({ domain: 'port', compose: 'docker-compose.yml' })
 
     await down({ yes: true })
 
-    expect(mocks.stopTraefik).toHaveBeenCalledTimes(1)
-    expect(mocks.runCompose).not.toHaveBeenCalled()
-    expect(mocks.unregisterProject).not.toHaveBeenCalled()
+    expect(mocks.runCompose).toHaveBeenCalledTimes(1)
+    expect(mocks.unregisterProject).toHaveBeenCalledWith('/repo', 'main')
   })
 
   test('exits cleanly when Traefik is not running', async () => {
@@ -150,7 +149,6 @@ describe('down fallback behavior', () => {
       name: 'main',
       isMainRepo: true,
     })
-    mocks.configExists.mockReturnValue(true)
     mocks.runCompose.mockRejectedValue(new Error('open .port/override.yml: no such file'))
     mocks.hasRegisteredProjects.mockResolvedValue(false)
     mocks.isTraefikRunning.mockResolvedValue(true)

--- a/src/commands/down.ts
+++ b/src/commands/down.ts
@@ -1,6 +1,6 @@
 import inquirer from 'inquirer'
 import { detectWorktree } from '../lib/worktree.ts'
-import { loadConfig, configExists, getComposeFile } from '../lib/config.ts'
+import { loadConfigOrDefault, getComposeFile, ensurePortRuntimeDir } from '../lib/config.ts'
 import {
   unregisterProject,
   hasRegisteredProjects,
@@ -72,15 +72,10 @@ export async function down(options?: { yes?: boolean }): Promise<void> {
 
   const { repoRoot, worktreePath, name } = worktreeInfo
 
-  // Check if port is initialized
-  if (!configExists(repoRoot)) {
-    output.info('Port is not initialized in this repository. Attempting global Traefik shutdown...')
-    await stopTraefikGlobally(options)
-    return
-  }
+  await ensurePortRuntimeDir(repoRoot)
 
-  // Load config
-  const config = await loadConfig(repoRoot)
+  // Load config (defaults when config file is absent)
+  const config = await loadConfigOrDefault(repoRoot)
   const composeFile = getComposeFile(config)
 
   // Stop docker-compose services

--- a/src/commands/enter.command.test.ts
+++ b/src/commands/enter.command.test.ts
@@ -4,8 +4,8 @@ const mocks = vi.hoisted(() => ({
   detectWorktree: vi.fn(),
   getWorktreePath: vi.fn(),
   worktreeExists: vi.fn(),
-  loadConfig: vi.fn(),
-  configExists: vi.fn(),
+  loadConfigOrDefault: vi.fn(),
+  ensurePortRuntimeDir: vi.fn(),
   getTreesDir: vi.fn(),
   getComposeFile: vi.fn(),
   branchExists: vi.fn(),
@@ -38,8 +38,8 @@ vi.mock('../lib/worktree.ts', () => ({
 }))
 
 vi.mock('../lib/config.ts', () => ({
-  loadConfig: mocks.loadConfig,
-  configExists: mocks.configExists,
+  loadConfigOrDefault: mocks.loadConfigOrDefault,
+  ensurePortRuntimeDir: mocks.ensurePortRuntimeDir,
   getTreesDir: mocks.getTreesDir,
   getComposeFile: mocks.getComposeFile,
 }))
@@ -112,8 +112,8 @@ describe('enter typo confirmation', () => {
       name: 'main',
       isMainRepo: true,
     })
-    mocks.configExists.mockReturnValue(true)
-    mocks.loadConfig.mockResolvedValue({ domain: 'port', compose: 'docker-compose.yml' })
+    mocks.ensurePortRuntimeDir.mockResolvedValue(undefined)
+    mocks.loadConfigOrDefault.mockResolvedValue({ domain: 'port', compose: 'docker-compose.yml' })
     mocks.getTreesDir.mockReturnValue('/tmp')
     mocks.getComposeFile.mockReturnValue('docker-compose.yml')
     mocks.worktreeExists.mockReturnValue(false)
@@ -238,8 +238,8 @@ describe('enter with shell hook eval file', () => {
       name: 'main',
       isMainRepo: true,
     })
-    mocks.configExists.mockReturnValue(true)
-    mocks.loadConfig.mockResolvedValue({ domain: 'port', compose: 'docker-compose.yml' })
+    mocks.ensurePortRuntimeDir.mockResolvedValue(undefined)
+    mocks.loadConfigOrDefault.mockResolvedValue({ domain: 'port', compose: 'docker-compose.yml' })
     mocks.getTreesDir.mockReturnValue('/tmp')
     mocks.getComposeFile.mockReturnValue('docker-compose.yml')
     mocks.worktreeExists.mockReturnValue(true)

--- a/src/commands/enter.test.ts
+++ b/src/commands/enter.test.ts
@@ -1,3 +1,4 @@
+import { existsSync } from 'fs'
 import { join } from 'path'
 import { execPortAsync, fetchWithTimeout, prepareSample, safeDown } from '@tests/utils'
 import { describe, test, expect } from 'vitest'
@@ -29,6 +30,35 @@ async function pollForText(url: string, maxWaitTime: number): Promise<string> {
 }
 
 describe('parallel worktrees', () => {
+  test(
+    'enter + up works without running port init first',
+    async () => {
+      const sample = await prepareSample('db-and-server', {
+        gitInit: true,
+      })
+
+      const branch = 'no-init-e2e'
+      const worktreeDir = join(sample.dir, `./.port/trees/${branch}`)
+      const url = `http://${branch}.port:3000`
+
+      try {
+        await execPortAsync(['enter', branch], sample.dir)
+        expect(existsSync(worktreeDir)).toBe(true)
+        expect(existsSync(join(sample.dir, '.port/.gitignore'))).toBe(true)
+
+        await execPortAsync(['up'], worktreeDir)
+        expect(existsSync(join(worktreeDir, '.port/override.yml'))).toBe(true)
+
+        const text = await pollForText(url, POLL_TIMEOUT)
+        expect(text).toContain('Hello from')
+      } finally {
+        await safeDown(worktreeDir)
+        await sample.cleanup()
+      }
+    },
+    TIMEOUT + 1000
+  )
+
   test(
     'separate worktrees have separate domains without conflict',
     async () => {

--- a/src/commands/enter.ts
+++ b/src/commands/enter.ts
@@ -1,6 +1,11 @@
 import { spawn } from 'child_process'
 import { detectWorktree, getWorktreePath, worktreeExists } from '../lib/worktree.ts'
-import { loadConfig, configExists, getTreesDir, getComposeFile } from '../lib/config.ts'
+import {
+  loadConfigOrDefault,
+  getTreesDir,
+  getComposeFile,
+  ensurePortRuntimeDir,
+} from '../lib/config.ts'
 import { branchExists, createWorktree, remoteBranchExists, removeWorktree } from '../lib/git.ts'
 import { writeOverrideFile, parseComposeFile, getProjectName } from '../lib/compose.ts'
 import { sanitizeBranchName } from '../lib/sanitize.ts'
@@ -30,14 +35,10 @@ export async function enter(branch: string): Promise<void> {
     process.exit(1)
   }
 
-  // Check if port is initialized
-  if (!configExists(repoRoot)) {
-    output.error('Port not initialized. Run "port init" first.')
-    process.exit(1)
-  }
+  await ensurePortRuntimeDir(repoRoot)
 
-  // Load config
-  const config = await loadConfig(repoRoot)
+  // Load config (defaults when config file is absent)
+  const config = await loadConfigOrDefault(repoRoot)
 
   // Sanitize branch name
   const sanitized = sanitizeBranchName(branch)

--- a/src/commands/init.ts
+++ b/src/commands/init.ts
@@ -9,6 +9,7 @@ import {
   HOOKS_DIR,
   POST_CREATE_HOOK,
   POST_UP_HOOK,
+  PORT_RUNTIME_GITIGNORE,
   getPortDir,
   getConfigPath,
   getTreesDir,
@@ -26,18 +27,6 @@ const CONFIG_TEMPLATE = `{
   // Path to docker-compose file (default: docker-compose.yml)
   "compose": "docker-compose.yml"
 }
-`
-
-/** .gitignore content for .port directory */
-const GITIGNORE_CONTENT = `# Ignore worktrees (they're local only)
-trees/
-
-# Generated override file for main repo
-override.yml
-override.user.yml
-
-# Hook logs
-logs/
 `
 
 /** Post-create hook template */
@@ -199,7 +188,7 @@ export async function init(): Promise<void> {
 
   // Create .gitignore if it doesn't exist
   if (!existsSync(gitignorePath)) {
-    await writeFile(gitignorePath, GITIGNORE_CONTENT)
+    await writeFile(gitignorePath, PORT_RUNTIME_GITIGNORE)
     output.success(`Created ${PORT_DIR}/.gitignore`)
   }
 

--- a/src/commands/list.test.ts
+++ b/src/commands/list.test.ts
@@ -3,7 +3,6 @@ import { beforeEach, describe, expect, test, vi } from 'vitest'
 
 const mocks = vi.hoisted(() => ({
   detectWorktree: vi.fn(),
-  configExists: vi.fn(),
   getTreesDir: vi.fn(),
   listWorktrees: vi.fn(),
 }))
@@ -13,7 +12,6 @@ vi.mock('../lib/worktree.ts', () => ({
 }))
 
 vi.mock('../lib/config.ts', () => ({
-  configExists: mocks.configExists,
   getTreesDir: mocks.getTreesDir,
 }))
 
@@ -36,7 +34,6 @@ describe('list command', () => {
   beforeEach(() => {
     vi.clearAllMocks()
     mocks.detectWorktree.mockReturnValue({ repoRoot: '/repo' })
-    mocks.configExists.mockReturnValue(true)
     mocks.getTreesDir.mockReturnValue('/repo/.port/trees')
     mocks.listWorktrees.mockResolvedValue([])
   })
@@ -118,13 +115,14 @@ describe('list command', () => {
     logSpy.mockRestore()
   })
 
-  test('outputs nothing when config does not exist', async () => {
+  test('still lists names when config does not exist', async () => {
     const logSpy = vi.spyOn(console, 'log').mockImplementation(() => undefined)
-    mocks.configExists.mockReturnValue(false)
+    vi.mocked(existsSync).mockReturnValue(false)
 
     await list()
 
-    expect(logSpy).not.toHaveBeenCalled()
+    const outputLines = logSpy.mock.calls.map(call => call[0])
+    expect(outputLines).toEqual(['repo'])
     logSpy.mockRestore()
   })
 

--- a/src/commands/list.ts
+++ b/src/commands/list.ts
@@ -1,6 +1,6 @@
 import { existsSync, readdirSync } from 'fs'
 import { detectWorktree } from '../lib/worktree.ts'
-import { configExists, getTreesDir } from '../lib/config.ts'
+import { getTreesDir } from '../lib/config.ts'
 import { sanitizeBranchName, sanitizeFolderName } from '../lib/sanitize.ts'
 import { listWorktrees } from '../lib/git.ts'
 
@@ -82,12 +82,11 @@ export async function getWorktreeNamesWithOriginals(repoRoot: string): Promise<s
 export async function list(): Promise<void> {
   try {
     const repoRoot = detectWorktree().repoRoot
-    if (!configExists(repoRoot)) return
     const names = await getWorktreeNamesWithOriginals(repoRoot)
     for (const name of names) {
       console.log(name)
     }
   } catch {
-    // Not in a git repo or no port config — output nothing
+    // Not in a git repo — output nothing
   }
 }

--- a/src/commands/prune.test.ts
+++ b/src/commands/prune.test.ts
@@ -1,0 +1,148 @@
+import { beforeEach, describe, expect, test, vi } from 'vitest'
+
+const mocks = vi.hoisted(() => ({
+  prompt: vi.fn(),
+  detectWorktree: vi.fn(),
+  ensurePortRuntimeDir: vi.fn(),
+  loadConfigOrDefault: vi.fn(),
+  getComposeFile: vi.fn(),
+  getDefaultBranch: vi.fn(),
+  getMergedBranches: vi.fn(),
+  getGoneBranches: vi.fn(),
+  fetchAndPrune: vi.fn(),
+  listWorktrees: vi.fn(),
+  isGhAvailable: vi.fn(),
+  getMergedPrBranches: vi.fn(),
+  removeWorktreeAndCleanup: vi.fn(),
+  sanitizeBranchName: vi.fn(),
+  failWithError: vi.fn(),
+  info: vi.fn(),
+  success: vi.fn(),
+  warn: vi.fn(),
+  newline: vi.fn(),
+  header: vi.fn(),
+  dim: vi.fn(),
+  branch: vi.fn(),
+}))
+
+vi.mock('inquirer', () => ({
+  default: {
+    prompt: mocks.prompt,
+  },
+}))
+
+vi.mock('../lib/worktree.ts', () => ({
+  detectWorktree: mocks.detectWorktree,
+}))
+
+vi.mock('../lib/config.ts', () => ({
+  ensurePortRuntimeDir: mocks.ensurePortRuntimeDir,
+  loadConfigOrDefault: mocks.loadConfigOrDefault,
+  getComposeFile: mocks.getComposeFile,
+}))
+
+vi.mock('../lib/git.ts', () => ({
+  getDefaultBranch: mocks.getDefaultBranch,
+  getMergedBranches: mocks.getMergedBranches,
+  getGoneBranches: mocks.getGoneBranches,
+  fetchAndPrune: mocks.fetchAndPrune,
+  listWorktrees: mocks.listWorktrees,
+}))
+
+vi.mock('../lib/github.ts', () => ({
+  isGhAvailable: mocks.isGhAvailable,
+  getMergedPrBranches: mocks.getMergedPrBranches,
+}))
+
+vi.mock('../lib/removal.ts', () => ({
+  removeWorktreeAndCleanup: mocks.removeWorktreeAndCleanup,
+}))
+
+vi.mock('../lib/sanitize.ts', () => ({
+  sanitizeBranchName: mocks.sanitizeBranchName,
+}))
+
+vi.mock('../lib/cli.ts', () => ({
+  failWithError: mocks.failWithError,
+}))
+
+vi.mock('../lib/output.ts', () => ({
+  info: mocks.info,
+  success: mocks.success,
+  warn: mocks.warn,
+  newline: mocks.newline,
+  header: mocks.header,
+  dim: mocks.dim,
+  branch: mocks.branch,
+}))
+
+import { prune } from './prune.ts'
+
+describe('prune command', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+
+    mocks.detectWorktree.mockReturnValue({ repoRoot: '/repo' })
+    mocks.ensurePortRuntimeDir.mockResolvedValue(undefined)
+    mocks.loadConfigOrDefault.mockResolvedValue({ domain: 'port', compose: 'docker-compose.yml' })
+    mocks.getComposeFile.mockReturnValue('docker-compose.yml')
+
+    mocks.fetchAndPrune.mockResolvedValue(undefined)
+    mocks.getDefaultBranch.mockResolvedValue('main')
+    mocks.listWorktrees.mockResolvedValue([
+      { path: '/repo', branch: 'main', isMain: true },
+      { path: '/repo/.port/trees/feature-a', branch: 'feature-a', isMain: false },
+    ])
+    mocks.getMergedBranches.mockResolvedValue(['feature-a'])
+    mocks.getGoneBranches.mockResolvedValue([])
+
+    mocks.isGhAvailable.mockResolvedValue(false)
+    mocks.getMergedPrBranches.mockResolvedValue(new Map())
+
+    mocks.removeWorktreeAndCleanup.mockResolvedValue({ success: true })
+    mocks.sanitizeBranchName.mockImplementation((name: string) => name)
+    mocks.branch.mockImplementation((name: string) => name)
+  })
+
+  test('supports dry-run mode without removing worktrees', async () => {
+    await prune({ dryRun: true })
+
+    expect(mocks.ensurePortRuntimeDir).toHaveBeenCalledWith('/repo')
+    expect(mocks.fetchAndPrune).toHaveBeenCalledWith('/repo')
+    expect(mocks.removeWorktreeAndCleanup).not.toHaveBeenCalled()
+    expect(mocks.dim).toHaveBeenCalledWith(
+      'Dry run — no changes made. Re-run without --dry-run to remove.'
+    )
+  })
+
+  test('removes candidates with --force using default config values', async () => {
+    await prune({ force: true })
+
+    expect(mocks.loadConfigOrDefault).toHaveBeenCalledWith('/repo')
+    expect(mocks.getComposeFile).toHaveBeenCalledWith({
+      domain: 'port',
+      compose: 'docker-compose.yml',
+    })
+    expect(mocks.removeWorktreeAndCleanup).toHaveBeenCalledWith(
+      {
+        repoRoot: '/repo',
+        composeFile: 'docker-compose.yml',
+        domain: 'port',
+      },
+      'feature-a',
+      expect.objectContaining({
+        branchAction: 'archive',
+        quiet: true,
+      })
+    )
+  })
+
+  test('reports clean state when no candidates are found', async () => {
+    mocks.getMergedBranches.mockResolvedValue([])
+
+    await prune({ force: true })
+
+    expect(mocks.success).toHaveBeenCalledWith('No merged worktrees found. Everything is clean.')
+    expect(mocks.removeWorktreeAndCleanup).not.toHaveBeenCalled()
+  })
+})

--- a/src/commands/prune.ts
+++ b/src/commands/prune.ts
@@ -1,6 +1,6 @@
 import inquirer from 'inquirer'
 import { detectWorktree } from '../lib/worktree.ts'
-import { loadConfig, configExists, getComposeFile } from '../lib/config.ts'
+import { loadConfigOrDefault, getComposeFile, ensurePortRuntimeDir } from '../lib/config.ts'
 import {
   getDefaultBranch,
   getMergedBranches,
@@ -116,9 +116,7 @@ export async function prune(options: PruneOptions = {}): Promise<void> {
     failWithError('Not in a git repository')
   }
 
-  if (!configExists(repoRoot)) {
-    failWithError('Port not initialized. Run "port init" first.')
-  }
+  await ensurePortRuntimeDir(repoRoot)
 
   // 1. Fetch and prune remote refs
   if (!options.noFetch) {
@@ -240,7 +238,7 @@ export async function prune(options: PruneOptions = {}): Promise<void> {
   }
 
   // 9. Remove each candidate
-  const config = await loadConfig(repoRoot)
+  const config = await loadConfigOrDefault(repoRoot)
   const composeFile = getComposeFile(config)
   const ctx = { repoRoot, composeFile, domain: config.domain }
 

--- a/src/commands/remove.test.ts
+++ b/src/commands/remove.test.ts
@@ -6,8 +6,8 @@ const mocks = vi.hoisted(() => ({
   detectWorktree: vi.fn(),
   worktreeExists: vi.fn(),
   getWorktreePath: vi.fn(),
-  configExists: vi.fn(),
-  loadConfig: vi.fn(),
+  ensurePortRuntimeDir: vi.fn(),
+  loadConfigOrDefault: vi.fn(),
   getComposeFile: vi.fn(),
   findWorktreeByBranch: vi.fn(),
   archiveBranch: vi.fn(),
@@ -44,8 +44,8 @@ vi.mock('../lib/worktree.ts', () => ({
 }))
 
 vi.mock('../lib/config.ts', () => ({
-  configExists: mocks.configExists,
-  loadConfig: mocks.loadConfig,
+  ensurePortRuntimeDir: mocks.ensurePortRuntimeDir,
+  loadConfigOrDefault: mocks.loadConfigOrDefault,
   getComposeFile: mocks.getComposeFile,
 }))
 
@@ -106,8 +106,8 @@ describe('remove command', () => {
     mocks.worktreeExists.mockReturnValue(true)
     mocks.getWorktreePath.mockReturnValue('/repo/.port/trees/demo-2')
 
-    mocks.configExists.mockReturnValue(true)
-    mocks.loadConfig.mockResolvedValue({ domain: 'port', compose: 'docker-compose.yml' })
+    mocks.ensurePortRuntimeDir.mockResolvedValue(undefined)
+    mocks.loadConfigOrDefault.mockResolvedValue({ domain: 'port', compose: 'docker-compose.yml' })
     mocks.getComposeFile.mockReturnValue('docker-compose.yml')
 
     mocks.findWorktreeByBranch.mockResolvedValue(null)

--- a/src/commands/remove.ts
+++ b/src/commands/remove.ts
@@ -1,7 +1,7 @@
 import inquirer from 'inquirer'
 import { detectWorktree, worktreeExists } from '../lib/worktree.ts'
 import type { WorktreeInfo } from '../types.ts'
-import { loadConfig, configExists, getComposeFile } from '../lib/config.ts'
+import { loadConfigOrDefault, getComposeFile, ensurePortRuntimeDir } from '../lib/config.ts'
 import { findWorktreeByBranch } from '../lib/git.ts'
 import { hasRegisteredProjects } from '../lib/registry.ts'
 import { stopTraefik, isTraefikRunning } from '../lib/compose.ts'
@@ -34,10 +34,7 @@ export async function remove(
     failWithError('Not in a git repository')
   }
 
-  // Check if port is initialized
-  if (!configExists(repoRoot)) {
-    failWithError('Port not initialized. Run "port init" first.')
-  }
+  await ensurePortRuntimeDir(repoRoot)
 
   // Auto-detect branch from current worktree when not specified
   if (!branch) {
@@ -111,8 +108,8 @@ export async function remove(
     await exit()
   }
 
-  // Load config
-  const config = await loadConfig(repoRoot)
+  // Load config (defaults when config file is absent)
+  const config = await loadConfigOrDefault(repoRoot)
   const composeFile = getComposeFile(config)
 
   output.info(`Removing worktree: ${output.branch(sanitized)}...`)

--- a/src/commands/run.test.ts
+++ b/src/commands/run.test.ts
@@ -2,14 +2,12 @@ import { test, expect, describe } from 'vitest'
 import { prepareSample, renderCLI } from '@tests/utils'
 
 describe('port run command', () => {
-  test('errors when not in a port-managed project', async () => {
-    const sample = await prepareSample('db-and-server', {
-      gitInit: true,
-    })
+  test('errors when not in a git repository', async () => {
+    const sample = await prepareSample('db-and-server')
 
     const { findByError } = await renderCLI(['run', '3000', '--', 'echo', 'hello'], sample.dir)
 
-    const instance = await findByError('Port not initialized')
+    const instance = await findByError('Not in a git repository')
     expect(instance).toBeInTheConsole()
 
     await sample.cleanup()

--- a/src/commands/run.ts
+++ b/src/commands/run.ts
@@ -1,7 +1,7 @@
 import { spawn, type ChildProcess } from 'child_process'
 import inquirer from 'inquirer'
 import { detectWorktree } from '../lib/worktree.ts'
-import { loadConfig, configExists } from '../lib/config.ts'
+import { loadConfigOrDefault, ensurePortRuntimeDir } from '../lib/config.ts'
 import { getHostService } from '../lib/registry.ts'
 import { ensureTraefikPorts, traefikFilesExist, initTraefikFiles } from '../lib/traefik.ts'
 import { startTraefik, isTraefikRunning, restartTraefik } from '../lib/compose.ts'
@@ -46,14 +46,10 @@ export async function run(logicalPort: number, command: string[]): Promise<void>
 
   const { repoRoot, name: branch } = worktreeInfo
 
-  // Check if port is initialized
-  if (!configExists(repoRoot)) {
-    output.error('Port not initialized. Run "port init" first.')
-    process.exit(1)
-  }
+  await ensurePortRuntimeDir(repoRoot)
 
-  // Load config to get domain
-  const config = await loadConfig(repoRoot)
+  // Load config to get domain (defaults when config file is absent)
+  const config = await loadConfigOrDefault(repoRoot)
   const domain = config.domain
 
   // Clean up stale host services

--- a/src/commands/up.command.test.ts
+++ b/src/commands/up.command.test.ts
@@ -2,8 +2,8 @@ import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest'
 
 const mocks = vi.hoisted(() => ({
   detectWorktree: vi.fn(),
-  configExists: vi.fn(),
-  loadConfig: vi.fn(),
+  ensurePortRuntimeDir: vi.fn(),
+  loadConfigOrDefault: vi.fn(),
   getComposeFile: vi.fn(),
   checkDns: vi.fn(),
   registerProject: vi.fn(),
@@ -40,8 +40,8 @@ vi.mock('../lib/worktree.ts', () => ({
 }))
 
 vi.mock('../lib/config.ts', () => ({
-  configExists: mocks.configExists,
-  loadConfig: mocks.loadConfig,
+  ensurePortRuntimeDir: mocks.ensurePortRuntimeDir,
+  loadConfigOrDefault: mocks.loadConfigOrDefault,
   getComposeFile: mocks.getComposeFile,
 }))
 
@@ -106,8 +106,8 @@ describe('up DNS preflight', () => {
       name: 'main',
       isMainRepo: true,
     })
-    mocks.configExists.mockReturnValue(true)
-    mocks.loadConfig.mockResolvedValue({ domain: 'port', compose: 'docker-compose.yml' })
+    mocks.ensurePortRuntimeDir.mockResolvedValue(undefined)
+    mocks.loadConfigOrDefault.mockResolvedValue({ domain: 'port', compose: 'docker-compose.yml' })
     mocks.getComposeFile.mockReturnValue('docker-compose.yml')
     mocks.checkDns.mockResolvedValue(true)
 
@@ -151,7 +151,7 @@ describe('up DNS preflight', () => {
   })
 
   test('exits early with custom-domain install command when DNS is not configured', async () => {
-    mocks.loadConfig.mockResolvedValue({ domain: 'custom', compose: 'docker-compose.yml' })
+    mocks.loadConfigOrDefault.mockResolvedValue({ domain: 'custom', compose: 'docker-compose.yml' })
     mocks.checkDns.mockResolvedValue(false)
 
     await expect(up()).rejects.toThrow('process.exit:1')

--- a/src/commands/up.ts
+++ b/src/commands/up.ts
@@ -1,5 +1,5 @@
 import { detectWorktree } from '../lib/worktree.ts'
-import { loadConfig, configExists, getComposeFile } from '../lib/config.ts'
+import { loadConfigOrDefault, getComposeFile, ensurePortRuntimeDir } from '../lib/config.ts'
 import { registerProject } from '../lib/registry.ts'
 import { ensureTraefikPorts, traefikFilesExist, initTraefikFiles } from '../lib/traefik.ts'
 import {
@@ -34,11 +34,7 @@ export async function up(): Promise<void> {
 
   const { repoRoot, worktreePath, name } = worktreeInfo
 
-  // Check if port is initialized
-  if (!configExists(repoRoot)) {
-    output.error('Port not initialized. Run "port init" first.')
-    process.exit(1)
-  }
+  await ensurePortRuntimeDir(repoRoot)
 
   // Check docker-compose version
   const { supported, version } = await checkComposeVersion()
@@ -50,8 +46,8 @@ export async function up(): Promise<void> {
     output.warn(`docker-compose v${version} detected. v2.24.0+ recommended for !override support.`)
   }
 
-  // Load config
-  const config = await loadConfig(repoRoot)
+  // Load config (defaults when config file is absent)
+  const config = await loadConfigOrDefault(repoRoot)
   const composeFile = getComposeFile(config)
 
   const dnsConfigured = await checkDns(config.domain)

--- a/src/commands/urls.test.ts
+++ b/src/commands/urls.test.ts
@@ -2,8 +2,8 @@ import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest'
 
 const mocks = vi.hoisted(() => ({
   detectWorktree: vi.fn(),
-  configExists: vi.fn(),
-  loadConfig: vi.fn(),
+  ensurePortRuntimeDir: vi.fn(),
+  loadConfigOrDefault: vi.fn(),
   getComposeFile: vi.fn(),
   parseComposeFile: vi.fn(),
   getServicePorts: vi.fn(),
@@ -21,8 +21,8 @@ vi.mock('../lib/worktree.ts', () => ({
 }))
 
 vi.mock('../lib/config.ts', () => ({
-  configExists: mocks.configExists,
-  loadConfig: mocks.loadConfig,
+  ensurePortRuntimeDir: mocks.ensurePortRuntimeDir,
+  loadConfigOrDefault: mocks.loadConfigOrDefault,
   getComposeFile: mocks.getComposeFile,
 }))
 
@@ -55,8 +55,8 @@ describe('urls command', () => {
       name: 'feature-1',
       isMainRepo: false,
     })
-    mocks.configExists.mockReturnValue(true)
-    mocks.loadConfig.mockResolvedValue({ domain: 'port', compose: 'docker-compose.yml' })
+    mocks.ensurePortRuntimeDir.mockResolvedValue(undefined)
+    mocks.loadConfigOrDefault.mockResolvedValue({ domain: 'port', compose: 'docker-compose.yml' })
     mocks.getComposeFile.mockReturnValue('docker-compose.yml')
     mocks.branch.mockImplementation((value: string) => value)
     mocks.getProjectName.mockReturnValue('repo-feature-1')

--- a/src/commands/urls.ts
+++ b/src/commands/urls.ts
@@ -1,5 +1,5 @@
 import { detectWorktree } from '../lib/worktree.ts'
-import { loadConfig, configExists, getComposeFile } from '../lib/config.ts'
+import { loadConfigOrDefault, getComposeFile, ensurePortRuntimeDir } from '../lib/config.ts'
 import { parseComposeFile, getServicePorts, composePs, getProjectName } from '../lib/compose.ts'
 import * as output from '../lib/output.ts'
 
@@ -17,12 +17,9 @@ export async function urls(serviceName?: string): Promise<void> {
 
   const { repoRoot, worktreePath, name } = worktreeInfo
 
-  if (!configExists(repoRoot)) {
-    output.error('Port not initialized. Run "port init" first.')
-    process.exit(1)
-  }
+  await ensurePortRuntimeDir(repoRoot)
 
-  const config = await loadConfig(repoRoot)
+  const config = await loadConfigOrDefault(repoRoot)
   const composeFile = getComposeFile(config)
   const projectName = getProjectName(repoRoot, name)
 

--- a/src/lib/config.test.ts
+++ b/src/lib/config.test.ts
@@ -1,5 +1,5 @@
-import { mkdtempSync } from 'fs'
-import { mkdir, rm, writeFile } from 'fs/promises'
+import { mkdtempSync, existsSync } from 'fs'
+import { mkdir, readFile, rm, writeFile } from 'fs/promises'
 import { tmpdir } from 'os'
 import { join } from 'path'
 import { afterEach, beforeEach, describe, expect, test } from 'vitest'
@@ -10,6 +10,9 @@ import {
   DEFAULT_DOMAIN,
   DEFAULT_COMPOSE,
   getComposeFile,
+  loadConfigOrDefault,
+  ensurePortRuntimeDir,
+  PORT_RUNTIME_GITIGNORE,
   loadConfig,
 } from './config.ts'
 
@@ -72,5 +75,72 @@ describe('loadConfig', () => {
     const config = await loadConfig(repoRoot)
 
     expect(config.domain).toBe(DEFAULT_DOMAIN)
+  })
+})
+
+describe('loadConfigOrDefault', () => {
+  let repoRoot: string
+
+  beforeEach(async () => {
+    repoRoot = createTempDir()
+    await mkdir(join(repoRoot, PORT_DIR), { recursive: true })
+  })
+
+  afterEach(async () => {
+    await rm(repoRoot, { recursive: true, force: true })
+  })
+
+  test('returns defaults when config file is missing', async () => {
+    const config = await loadConfigOrDefault(repoRoot)
+
+    expect(config.domain).toBe(DEFAULT_DOMAIN)
+    expect(config.compose).toBe(DEFAULT_COMPOSE)
+  })
+
+  test('loads explicit config when file exists', async () => {
+    const configPath = join(repoRoot, PORT_DIR, CONFIG_FILE)
+    await writeFile(configPath, '{"domain": "custom", "compose": "compose.dev.yml"}')
+
+    const config = await loadConfigOrDefault(repoRoot)
+
+    expect(config.domain).toBe('custom')
+    expect(config.compose).toBe('compose.dev.yml')
+  })
+})
+
+describe('ensurePortRuntimeDir', () => {
+  let repoRoot: string
+
+  beforeEach(() => {
+    repoRoot = createTempDir()
+  })
+
+  afterEach(async () => {
+    await rm(repoRoot, { recursive: true, force: true })
+  })
+
+  test('creates .port directory and .gitignore when missing', async () => {
+    await ensurePortRuntimeDir(repoRoot)
+
+    const portDir = join(repoRoot, PORT_DIR)
+    const gitignorePath = join(portDir, '.gitignore')
+
+    expect(existsSync(portDir)).toBe(true)
+    expect(existsSync(gitignorePath)).toBe(true)
+
+    const gitignore = await readFile(gitignorePath, 'utf-8')
+    expect(gitignore).toBe(PORT_RUNTIME_GITIGNORE)
+  })
+
+  test('does not overwrite an existing .gitignore', async () => {
+    const portDir = join(repoRoot, PORT_DIR)
+    const gitignorePath = join(portDir, '.gitignore')
+    await mkdir(portDir, { recursive: true })
+    await writeFile(gitignorePath, 'custom-ignore')
+
+    await ensurePortRuntimeDir(repoRoot)
+
+    const gitignore = await readFile(gitignorePath, 'utf-8')
+    expect(gitignore).toBe('custom-ignore')
   })
 })

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -1,4 +1,4 @@
-import { readFile } from 'fs/promises'
+import { readFile, mkdir, writeFile } from 'fs/promises'
 import { existsSync } from 'fs'
 import { join } from 'path'
 import { parse as parseJsonc, type ParseError } from 'jsonc-parser'
@@ -41,6 +41,18 @@ export const DEFAULT_DOMAIN = 'port'
 
 /** Default docker-compose file */
 export const DEFAULT_COMPOSE = 'docker-compose.yml'
+
+/** .gitignore content for runtime-only .port files */
+export const PORT_RUNTIME_GITIGNORE = `# Ignore worktrees (they're local only)
+trees/
+
+# Generated override file for main repo
+override.yml
+override.user.yml
+
+# Hook logs
+logs/
+`
 
 /**
  * Error thrown when config validation fails
@@ -141,6 +153,34 @@ export async function loadConfig(repoRoot: string): Promise<PortConfig> {
   }
 
   return validateConfig(config)
+}
+
+/**
+ * Load project config when present, otherwise return defaults.
+ */
+export async function loadConfigOrDefault(repoRoot: string): Promise<PortConfig> {
+  if (!configExists(repoRoot)) {
+    return {
+      domain: DEFAULT_DOMAIN,
+      compose: DEFAULT_COMPOSE,
+    }
+  }
+
+  return loadConfig(repoRoot)
+}
+
+/**
+ * Ensure runtime .port directory exists with a local .gitignore.
+ */
+export async function ensurePortRuntimeDir(repoRoot: string): Promise<void> {
+  const portDir = getPortDir(repoRoot)
+  const gitignorePath = join(portDir, '.gitignore')
+
+  await mkdir(portDir, { recursive: true })
+
+  if (!existsSync(gitignorePath)) {
+    await writeFile(gitignorePath, PORT_RUNTIME_GITIGNORE)
+  }
 }
 
 /**

--- a/tests/compose.test.ts
+++ b/tests/compose.test.ts
@@ -28,11 +28,12 @@ describe('port compose command', () => {
     await sample.cleanup()
   })
 
-  test('errors when port is not initialized', async () => {
+  test('uses default runtime config when port is not initialized', async () => {
     const sample = await prepareSample('db-and-server', { gitInit: true })
-    // Initialize git but not port
+    // Initialize git but not port config
     const result = await execPortAsync(['compose', 'ps'], sample.dir).catch(e => e)
-    expect(result.stderr).toContain('Port not initialized')
+    expect(result.stderr).toContain('Override file not found')
+    expect(result.stderr).toContain('port up')
     await sample.cleanup()
   })
 

--- a/tests/urls.test.ts
+++ b/tests/urls.test.ts
@@ -1,3 +1,4 @@
+import { existsSync } from 'fs'
 import { describe, test, expect } from 'vitest'
 import { prepareSample, execPortAsync } from './utils'
 
@@ -49,12 +50,14 @@ describe('port urls command', () => {
     }
   })
 
-  test('errors when port is not initialized', async () => {
+  test('uses defaults and creates runtime .port/.gitignore when config is missing', async () => {
     const sample = await prepareSample('db-and-server', { gitInit: true })
 
     try {
-      const result = await execPortAsync(['urls'], sample.dir).catch(e => e)
-      expect(result.stderr).toContain('Port not initialized')
+      const result = await execPortAsync(['urls'], sample.dir)
+      expect(result.stderr).toContain(sample.urlWithPort(3000))
+      expect(result.stderr).toContain(sample.urlWithPort(5432))
+      expect(existsSync(`${sample.dir}/.port/.gitignore`)).toBe(true)
     } finally {
       await sample.cleanup()
     }


### PR DESCRIPTION
## Summary
- Make `port init` optional for core workflows by adding runtime defaults and implicit `.port` bootstrap (`.port/.gitignore`) so `enter`, `up`, `run`, `urls`, `compose`, `down`, `remove`, `prune`, and `list` work in newly git-initialized repos without config scaffolding.
- Update docs and tests to reflect no-init behavior, including a new `prune` command test suite and an integration smoke test that verifies `enter -> up` succeeds without `port init`.
## Testing
- Ran targeted unit/command and integration suites covering config helpers and no-init command flows, including `src/lib/config.test.ts`, command tests (`enter`, `up`, `urls`, `down`, `remove`, `list`, `prune`, `run`), and integration tests (`tests/compose.test.ts`, `tests/urls.test.ts`, `src/commands/enter.test.ts`).
- Result: all listed test runs passed after Docker availability was restored for the `enter` integration suite.
## Risks
- Implicitly creating `.port/` and `.port/.gitignore` changes first-run side effects for commands that previously failed before creating runtime files.
- Mitigation: behavior is documented, `port init` remains available for explicit project scaffolding, and coverage now includes no-init integration paths.