### PR TITLE
Non-blocking TUI actions

### DIFF
--- a/src/lib/compose.stream.test.ts
+++ b/src/lib/compose.stream.test.ts
@@ -1,0 +1,77 @@
+import { beforeEach, describe, expect, test, vi } from 'vitest'
+
+const { execStreamingMock, execWithStdioMock, execAsyncMock } = vi.hoisted(() => ({
+  execStreamingMock: vi.fn(),
+  execWithStdioMock: vi.fn(),
+  execAsyncMock: vi.fn(),
+}))
+
+vi.mock('./exec.ts', () => ({
+  execAsync: execAsyncMock,
+  execStreaming: execStreamingMock,
+  execWithStdio: execWithStdioMock,
+}))
+
+import { runCompose } from './compose.ts'
+
+describe('runCompose stream mode', () => {
+  beforeEach(() => {
+    execStreamingMock.mockReset()
+    execWithStdioMock.mockReset()
+    execAsyncMock.mockReset()
+  })
+
+  test('routes stdio=stream through execStreaming and forwards hooks', async () => {
+    const onStdoutLine = vi.fn()
+    const onStderrLine = vi.fn()
+    const controller = new AbortController()
+
+    execStreamingMock.mockResolvedValue({ exitCode: 0 })
+
+    const result = await runCompose(
+      '/repo/.port/trees/feature-a',
+      'docker-compose.yml',
+      'repo-feature-a',
+      ['up', '-d'],
+      { repoRoot: '/repo', branch: 'feature-a', domain: 'port' },
+      {
+        stdio: 'stream',
+        signal: controller.signal,
+        onStdoutLine,
+        onStderrLine,
+      }
+    )
+
+    expect(result).toEqual({ exitCode: 0 })
+    expect(execStreamingMock).toHaveBeenCalledTimes(1)
+
+    const [command, options] = execStreamingMock.mock.calls[0] as [string, Record<string, unknown>]
+    expect(command).toContain('docker compose')
+    expect(options.cwd).toBe('/repo/.port/trees/feature-a')
+    expect(options.signal).toBe(controller.signal)
+    expect(options.onStdoutLine).toBe(onStdoutLine)
+    expect(options.onStderrLine).toBe(onStderrLine)
+    expect(execWithStdioMock).not.toHaveBeenCalled()
+    expect(execAsyncMock).toHaveBeenCalledTimes(1)
+    expect(execAsyncMock).toHaveBeenCalledWith('docker compose version')
+  })
+
+  test('does not call execStreaming in capture mode', async () => {
+    execAsyncMock.mockResolvedValue({ stdout: 'ok', stderr: '' })
+
+    const result = await runCompose(
+      '/repo/.port/trees/feature-a',
+      'docker-compose.yml',
+      'repo-feature-a',
+      ['down'],
+      { repoRoot: '/repo', branch: 'feature-a', domain: 'port' },
+      {
+        stdio: 'capture',
+      }
+    )
+
+    expect(result).toEqual({ exitCode: 0, stdout: 'ok', stderr: '' })
+    expect(execStreamingMock).not.toHaveBeenCalled()
+    expect(execAsyncMock).toHaveBeenCalledTimes(2)
+  })
+})

--- a/src/lib/compose.ts
+++ b/src/lib/compose.ts
@@ -4,7 +4,7 @@ import { basename, join } from 'path'
 import { stringify as yamlStringify } from 'yaml'
 import type { ParsedComposeFile, ParsedComposeService } from '../types.ts'
 import { TRAEFIK_NETWORK, TRAEFIK_DIR } from './traefik.ts'
-import { execAsync, execWithStdio } from './exec.ts'
+import { execAsync, execStreaming, execWithStdio } from './exec.ts'
 import { sanitizeFolderName } from './sanitize.ts'
 
 /** Override file name */
@@ -507,7 +507,10 @@ export interface ComposeRunOptions {
    * 'inherit' streams output to the terminal (default, used by CLI commands).
    * 'capture' captures stdout/stderr and returns them (used by TUI).
    */
-  stdio?: 'inherit' | 'capture'
+  stdio?: 'inherit' | 'capture' | 'stream'
+  onStdoutLine?: (line: string) => void
+  onStderrLine?: (line: string) => void
+  signal?: AbortSignal
 }
 
 /** Result from a compose command run in capture mode */
@@ -591,6 +594,15 @@ export async function runCompose(
         stderr: err.stderr ?? '',
       }
     }
+  }
+
+  if (options?.stdio === 'stream') {
+    return execStreaming(fullCommand, {
+      cwd,
+      onStdoutLine: options.onStdoutLine,
+      onStderrLine: options.onStderrLine,
+      signal: options.signal,
+    })
   }
 
   return execWithStdio(fullCommand, { cwd })

--- a/src/lib/exec.ts
+++ b/src/lib/exec.ts
@@ -200,14 +200,20 @@ export async function execStreaming(
       stdoutReader?.close()
       stderrReader?.close()
       if (killTimer) clearTimeout(killTimer)
+      if (options.signal) {
+        options.signal.removeEventListener('abort', abortHandler)
+      }
       reject(error)
     })
 
-    child.on('close', code => {
+    child.on('close', (code, signal) => {
       stdoutReader?.close()
       stderrReader?.close()
       if (killTimer) clearTimeout(killTimer)
-      resolve({ exitCode: code ?? 0 })
+      if (options.signal) {
+        options.signal.removeEventListener('abort', abortHandler)
+      }
+      resolve({ exitCode: code ?? (signal ? 130 : 0) })
     })
   })
 }

--- a/src/lib/exec.ts
+++ b/src/lib/exec.ts
@@ -1,5 +1,6 @@
 import { exec, spawn, type SpawnOptions } from 'child_process'
 import { promisify } from 'util'
+import { createInterface } from 'readline'
 
 /**
  * Promisified version of child_process.exec
@@ -136,6 +137,76 @@ export async function execWithStdio(
       // which keeps the event loop alive after the child exits. Unref it
       // so the parent process can exit naturally once all work is done.
       process.stdin.unref()
+      resolve({ exitCode: code ?? 0 })
+    })
+  })
+}
+
+interface ExecStreamingOptions {
+  cwd?: string
+  signal?: AbortSignal
+  onStdoutLine?: (line: string) => void
+  onStderrLine?: (line: string) => void
+}
+
+/**
+ * Execute a command and stream stdout/stderr line-by-line to callbacks.
+ */
+export async function execStreaming(
+  command: string,
+  options: ExecStreamingOptions = {}
+): Promise<{ exitCode: number }> {
+  return new Promise((resolve, reject) => {
+    const spawnOptions: SpawnOptions = {
+      cwd: options.cwd,
+      stdio: ['ignore', 'pipe', 'pipe'],
+      shell: true,
+    }
+
+    const child = spawn(command, [], spawnOptions)
+
+    const stdoutReader = child.stdout
+      ? createInterface({ input: child.stdout, crlfDelay: Infinity })
+      : null
+    const stderrReader = child.stderr
+      ? createInterface({ input: child.stderr, crlfDelay: Infinity })
+      : null
+
+    stdoutReader?.on('line', line => {
+      options.onStdoutLine?.(line)
+    })
+
+    stderrReader?.on('line', line => {
+      options.onStderrLine?.(line)
+    })
+
+    let killTimer: ReturnType<typeof setTimeout> | null = null
+    const abortHandler = () => {
+      child.kill('SIGINT')
+      killTimer = setTimeout(() => {
+        child.kill('SIGTERM')
+      }, 1500)
+    }
+
+    if (options.signal) {
+      if (options.signal.aborted) {
+        abortHandler()
+      } else {
+        options.signal.addEventListener('abort', abortHandler, { once: true })
+      }
+    }
+
+    child.on('error', error => {
+      stdoutReader?.close()
+      stderrReader?.close()
+      if (killTimer) clearTimeout(killTimer)
+      reject(error)
+    })
+
+    child.on('close', code => {
+      stdoutReader?.close()
+      stderrReader?.close()
+      if (killTimer) clearTimeout(killTimer)
       resolve({ exitCode: code ?? 0 })
     })
   })

--- a/src/lib/execStreaming.test.ts
+++ b/src/lib/execStreaming.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, test } from 'bun:test'
+import { describe, expect, test } from 'vitest'
 import { execStreaming } from './exec.ts'
 
 describe('execStreaming', () => {

--- a/src/lib/execStreaming.test.ts
+++ b/src/lib/execStreaming.test.ts
@@ -19,11 +19,11 @@ describe('execStreaming', () => {
     expect(stderr).toEqual(['err-1'])
   })
 
-  test('supports cancellation through AbortSignal', async () => {
+  test('supports cancellation through AbortSignal', { timeout: 15000 }, async () => {
     const stdout: string[] = []
     const controller = new AbortController()
 
-    const run = execStreaming(`bun -e "setInterval(() => console.log('tick'), 50)"`, {
+    const run = execStreaming(`while true; do echo tick; sleep 0.05; done`, {
       signal: controller.signal,
       onStdoutLine: line => stdout.push(line),
     })

--- a/src/lib/execStreaming.test.ts
+++ b/src/lib/execStreaming.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, test } from 'bun:test'
+import { execStreaming } from './exec.ts'
+
+describe('execStreaming', () => {
+  test('streams stdout and stderr lines', async () => {
+    const stdout: string[] = []
+    const stderr: string[] = []
+
+    const result = await execStreaming(
+      `bun -e "console.log('out-1'); console.log('out-2'); console.error('err-1')"`,
+      {
+        onStdoutLine: line => stdout.push(line),
+        onStderrLine: line => stderr.push(line),
+      }
+    )
+
+    expect(result.exitCode).toBe(0)
+    expect(stdout).toEqual(['out-1', 'out-2'])
+    expect(stderr).toEqual(['err-1'])
+  })
+
+  test('supports cancellation through AbortSignal', async () => {
+    const stdout: string[] = []
+    const controller = new AbortController()
+
+    const run = execStreaming(`bun -e "setInterval(() => console.log('tick'), 50)"`, {
+      signal: controller.signal,
+      onStdoutLine: line => stdout.push(line),
+    })
+
+    setTimeout(() => controller.abort(), 140)
+
+    const result = await run
+    expect(result.exitCode).toBe(130)
+    expect(stdout.length).toBeGreaterThan(0)
+  })
+})

--- a/src/tui/App.tsx
+++ b/src/tui/App.tsx
@@ -1,4 +1,4 @@
-import { useState, useCallback } from 'react'
+import { useState, useCallback, useRef } from 'react'
 import { useKeyboard } from '@opentui/react'
 import type { WorktreeInfo, PortConfig } from '../types.ts'
 import type { StartView, ExitInfo } from './index.tsx'
@@ -6,6 +6,37 @@ import { Dashboard } from './views/Dashboard.tsx'
 import { WorktreeView } from './views/WorktreeView.tsx'
 import { usePortData } from './hooks/usePortData.ts'
 import { useActions } from './hooks/useActions.ts'
+
+export async function runGracefulExit(params: {
+  getExitInfo: () => ExitInfo
+  requestExit: (info: ExitInfo) => void
+  getRunningActionCount: () => number
+  shutdownJobs: (options?: { timeoutMs?: number }) => Promise<{
+    cancelledCount: number
+    timedOut: boolean
+    remaining: number
+  }>
+  setStatus: (text: string, type: 'success' | 'error') => void
+  setExiting: (exiting: boolean) => void
+}): Promise<void> {
+  params.setExiting(true)
+  const runningCount = params.getRunningActionCount()
+  if (runningCount > 0) {
+    params.setStatus(
+      `Exiting... cancelling ${runningCount} running action${runningCount === 1 ? '' : 's'}`,
+      'success'
+    )
+    const shutdown = await params.shutdownJobs({ timeoutMs: 5000 })
+    if (shutdown.timedOut) {
+      params.setStatus(
+        `Shutdown timed out with ${shutdown.remaining} action${shutdown.remaining === 1 ? '' : 's'} still running`,
+        'error'
+      )
+    }
+  }
+
+  params.requestExit(params.getExitInfo())
+}
 
 interface AppProps {
   startView: StartView
@@ -21,6 +52,8 @@ export function App({ startView, context, config, requestExit }: AppProps) {
     text: string
     type: 'success' | 'error'
   } | null>(null)
+  const [isExiting, setIsExiting] = useState(false)
+  const exitingRef = useRef(false)
 
   // Track which worktree is "active" (where the shell will cd on exit).
   const activeWorktreeName = context.name
@@ -38,6 +71,10 @@ export function App({ startView, context, config, requestExit }: AppProps) {
   const actions = useActions(context.repoRoot, config, refresh)
 
   const showStatus = useCallback((text: string, type: 'success' | 'error') => {
+    if (exitingRef.current) {
+      setStatusMessage({ text, type })
+      return
+    }
     setStatusMessage({ text, type })
     setTimeout(() => setStatusMessage(null), 3000)
   }, [])
@@ -64,26 +101,51 @@ export function App({ startView, context, config, requestExit }: AppProps) {
     [worktrees, context, requestExit]
   )
 
-  const handleExit = useCallback(() => {
+  const buildExitInfo = useCallback((): ExitInfo => {
     const activeName = activeWorktreeName
     const activeWt = worktrees.find(w => w.name === activeName)
     const worktreePath = activeWt?.path ?? context.worktreePath
 
-    requestExit({
+    return {
       activeWorktreeName: activeName,
       worktreePath,
       changed: activeName !== context.name,
+    }
+  }, [activeWorktreeName, worktrees, context])
+
+  const handleExit = useCallback(async () => {
+    if (exitingRef.current) {
+      return
+    }
+    exitingRef.current = true
+
+    await runGracefulExit({
+      getExitInfo: buildExitInfo,
+      requestExit,
+      getRunningActionCount: actions.getRunningActionCount,
+      shutdownJobs: actions.shutdownJobs,
+      setStatus: (text, type) => setStatusMessage({ text, type }),
+      setExiting: setIsExiting,
     })
-  }, [activeWorktreeName, worktrees, context, requestExit])
+  }, [actions.getRunningActionCount, actions.shutdownJobs, buildExitInfo, requestExit])
+
+  const handleForceExit = useCallback(() => {
+    requestExit(buildExitInfo())
+  }, [buildExitInfo, requestExit])
 
   useKeyboard(event => {
     if (event.name === 'q' && !event.ctrl && !event.meta) {
-      handleExit()
+      void handleExit()
     }
     if (event.name === 'c' && event.ctrl) {
-      handleExit()
+      if (exitingRef.current) {
+        handleForceExit()
+      } else {
+        void handleExit()
+      }
     }
     if (event.name === 'r' && !event.ctrl && !event.meta) {
+      if (isExiting) return
       refresh()
     }
   })

--- a/src/tui/__tests__/App.exit.test.ts
+++ b/src/tui/__tests__/App.exit.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, mock, test } from 'bun:test'
+import type { ExitInfo } from '../index.tsx'
+import { runGracefulExit } from '../App.tsx'
+
+describe('runGracefulExit', () => {
+  const exitInfo: ExitInfo = {
+    activeWorktreeName: 'myapp',
+    worktreePath: '/repo',
+    changed: false,
+  }
+
+  test('requests exit immediately when no actions are running', async () => {
+    const setStatus = mock(() => {})
+    const setExiting = mock(() => {})
+    const requestExit = mock(() => {})
+
+    await runGracefulExit({
+      getExitInfo: () => exitInfo,
+      requestExit,
+      getRunningActionCount: () => 0,
+      shutdownJobs: async () => ({ cancelledCount: 0, timedOut: false, remaining: 0 }),
+      setStatus,
+      setExiting,
+    })
+
+    expect(setExiting).toHaveBeenCalledWith(true)
+    expect(setStatus).not.toHaveBeenCalled()
+    expect(requestExit).toHaveBeenCalledWith(exitInfo)
+  })
+
+  test('waits for shutdown and reports timeout before exit', async () => {
+    const setStatusCalls: Array<{ text: string; type: 'success' | 'error' }> = []
+    const requestExit = mock(() => {})
+    let shutdownCalled = false
+
+    await runGracefulExit({
+      getExitInfo: () => exitInfo,
+      requestExit,
+      getRunningActionCount: () => 2,
+      shutdownJobs: async () => {
+        shutdownCalled = true
+        return { cancelledCount: 2, timedOut: true, remaining: 1 }
+      },
+      setStatus: (text, type) => {
+        setStatusCalls.push({ text, type })
+      },
+      setExiting: () => {},
+    })
+
+    expect(shutdownCalled).toBe(true)
+    expect(setStatusCalls[0]).toEqual({
+      text: 'Exiting... cancelling 2 running actions',
+      type: 'success',
+    })
+    expect(setStatusCalls[1]).toEqual({
+      text: 'Shutdown timed out with 1 action still running',
+      type: 'error',
+    })
+    expect(requestExit).toHaveBeenCalledWith(exitInfo)
+  })
+})

--- a/src/tui/__tests__/Dashboard.test.tsx
+++ b/src/tui/__tests__/Dashboard.test.tsx
@@ -71,13 +71,8 @@ const mockActions = {
   archiveWorktree: noopAction,
   isWorktreeBusy: () => false,
   latestJobByWorktree: new Map(),
-  jobs: [],
-  logOpen: false,
-  activeLogJob: null,
-  toggleLog: noop,
-  selectNextLogJob: noop,
-  selectPrevLogJob: noop,
-  cancelActiveLogJob: () => false,
+  getOutputTail: () => [],
+  cancelWorktreeAction: () => false,
 }
 
 /** Common Dashboard props with defaults for testing */
@@ -202,8 +197,40 @@ describe('Dashboard', () => {
     expect(frame).toContain('[u]')
     expect(frame).toContain('[d]')
     expect(frame).toContain('[a]')
-    expect(frame).toContain('[r]')
-    expect(frame).toContain('[q]')
+    expect(frame).not.toContain('[c]')
+  })
+
+  test('shows cancel hint only when selected worktree has running action', async () => {
+    const { renderer, renderOnce, captureCharFrame } = await testRender(
+      <Dashboard
+        {...props({
+          actions: {
+            ...mockActions,
+            isWorktreeBusy: (name: string) => name === 'myapp',
+            latestJobByWorktree: new Map([
+              [
+                'myapp',
+                {
+                  id: 'job-running',
+                  kind: 'up',
+                  worktreeName: 'myapp',
+                  worktreePath: '/repo',
+                  status: 'running',
+                  summary: 'up',
+                  logs: [],
+                },
+              ],
+            ]),
+          },
+        })}
+      />,
+      { width: 110, height: 20 }
+    )
+    currentRenderer = renderer
+
+    await renderOnce()
+    const frame = captureCharFrame()
+    expect(frame).toContain('[c]')
   })
 
   test('j/k navigates worktree list', async () => {
@@ -328,23 +355,17 @@ describe('Dashboard', () => {
     expect(frame).toContain('down failed')
   })
 
-  test('supports log toggle and job cycling keys', async () => {
-    const toggles: string[] = []
+  test('c triggers cancellation for selected worktree', async () => {
+    const cancelled: string[] = []
 
     const { renderer, mockInput, renderOnce } = await testRender(
       <Dashboard
         {...props({
           actions: {
             ...mockActions,
-            logOpen: true,
-            toggleLog: () => {
-              toggles.push('toggle')
-            },
-            selectPrevLogJob: () => {
-              toggles.push('prev')
-            },
-            selectNextLogJob: () => {
-              toggles.push('next')
+            cancelWorktreeAction: (name: string) => {
+              cancelled.push(name)
+              return true
             },
           },
         })}
@@ -354,11 +375,9 @@ describe('Dashboard', () => {
     currentRenderer = renderer
 
     await renderOnce()
-    await pressAndRender(mockInput, renderOnce, '[')
-    await pressAndRender(mockInput, renderOnce, ']')
-    await pressAndRender(mockInput, renderOnce, 'l')
+    await pressAndRender(mockInput, renderOnce, 'c')
 
-    expect(toggles).toEqual(['prev', 'next', 'toggle'])
+    expect(cancelled).toEqual(['myapp'])
   })
 
   test('shows cancel status error when no running job is selected', async () => {
@@ -369,8 +388,7 @@ describe('Dashboard', () => {
         {...props({
           actions: {
             ...mockActions,
-            logOpen: true,
-            cancelActiveLogJob: () => false,
+            cancelWorktreeAction: () => false,
           },
           showStatus: (text: string, type: 'success' | 'error') => {
             statusCalls.push({ text, type })
@@ -387,25 +405,18 @@ describe('Dashboard', () => {
     expect(statusCalls).toEqual([{ text: 'No running action selected to cancel', type: 'error' }])
   })
 
-  test('renders action log panel when log is open', async () => {
-    const activeJob = {
-      id: 'job-1',
-      kind: 'up',
-      worktreeName: 'myapp',
-      worktreePath: '/repo',
-      status: 'running' as const,
-      summary: 'up',
-      logs: [{ ts: 1, stream: 'system' as const, line: 'Starting up' }],
-    }
+  test('renders two-line output tail for selected worktree', async () => {
+    const tail = [
+      { stream: 'stdout' as const, line: 'Building app...' },
+      { stream: 'stderr' as const, line: 'warning: cache miss' },
+    ]
 
     const { renderer, renderOnce, captureCharFrame } = await testRender(
       <Dashboard
         {...props({
           actions: {
             ...mockActions,
-            logOpen: true,
-            jobs: [activeJob],
-            activeLogJob: activeJob,
+            getOutputTail: () => tail,
           },
         })}
       />,
@@ -416,8 +427,99 @@ describe('Dashboard', () => {
     await renderOnce()
     const frame = captureCharFrame()
 
-    expect(frame).toContain('Action Log')
-    expect(frame).toContain('myapp up running')
+    expect(frame).toContain('Output (myapp)')
+    expect(frame).toContain('Building app...')
+    expect(frame).toContain('warning: cache miss')
+  })
+
+  test('shows running and finished output titles with elapsed seconds', async () => {
+    const runningJob = {
+      id: 'job-running',
+      kind: 'up' as const,
+      worktreeName: 'myapp',
+      worktreePath: '/repo',
+      status: 'running' as const,
+      summary: 'up',
+      startedAt: 1_000,
+      logs: [],
+    }
+    const finishedJob = {
+      ...runningJob,
+      id: 'job-finished',
+      status: 'success' as const,
+      endedAt: 4_200,
+    }
+
+    const {
+      renderer: runningRenderer,
+      renderOnce: renderRunning,
+      captureCharFrame: captureRunning,
+    } = await testRender(
+      <Dashboard
+        {...props({
+          actions: {
+            ...mockActions,
+            isWorktreeBusy: (name: string) => name === 'myapp',
+            latestJobByWorktree: new Map([['myapp', runningJob]]),
+          },
+        })}
+      />,
+      { width: 110, height: 24 }
+    )
+    currentRenderer = runningRenderer
+    await renderRunning()
+    expect(captureRunning()).toContain('Output (myapp) - running')
+
+    const {
+      renderer: finishedRenderer,
+      renderOnce: renderFinished,
+      captureCharFrame: captureFinished,
+    } = await testRender(
+      <Dashboard
+        {...props({
+          actions: {
+            ...mockActions,
+            latestJobByWorktree: new Map([['myapp', finishedJob]]),
+            getOutputTail: () => [{ stream: 'stdout', line: 'done' }],
+          },
+        })}
+      />,
+      { width: 110, height: 24 }
+    )
+    currentRenderer = finishedRenderer
+    await renderFinished()
+    expect(captureFinished()).toContain('Output (myapp) - finished in 3s')
+  })
+
+  test('shows failure-specific output title wording', async () => {
+    const failedJob = {
+      id: 'job-failed',
+      kind: 'down' as const,
+      worktreeName: 'myapp',
+      worktreePath: '/repo',
+      status: 'error' as const,
+      summary: 'down',
+      startedAt: 2_000,
+      endedAt: 6_100,
+      logs: [],
+    }
+
+    const { renderer, renderOnce, captureCharFrame } = await testRender(
+      <Dashboard
+        {...props({
+          actions: {
+            ...mockActions,
+            latestJobByWorktree: new Map([['myapp', failedJob]]),
+            getOutputTail: () => [{ stream: 'stderr', line: 'failed' }],
+          },
+        })}
+      />,
+      { width: 110, height: 24 }
+    )
+    currentRenderer = renderer
+    await renderOnce()
+
+    expect(captureCharFrame()).toContain('Output (myapp) - failed in 4s')
   })
 
   test('Enter calls onSelectWorktree', async () => {

--- a/src/tui/__tests__/Dashboard.test.tsx
+++ b/src/tui/__tests__/Dashboard.test.tsx
@@ -71,6 +71,12 @@ const mockActions = {
   archiveWorktree: noopAction,
   isWorktreeBusy: () => false,
   latestJobByWorktree: new Map(),
+  jobs: [],
+  logOpen: false,
+  activeLogJob: null,
+  toggleLog: noop,
+  selectNextLogJob: noop,
+  selectPrevLogJob: noop,
 }
 
 /** Common Dashboard props with defaults for testing */

--- a/src/tui/__tests__/Dashboard.test.tsx
+++ b/src/tui/__tests__/Dashboard.test.tsx
@@ -4,7 +4,7 @@ import type { TestRenderer } from '@opentui/core/testing'
 import { useEffect, useState } from 'react'
 import type { WorktreeStatus } from '../../lib/worktreeStatus.ts'
 import type { HostService, PortConfig } from '../../types.ts'
-import type { ActionResult } from '../hooks/useActions.ts'
+import type { EnqueueResult } from '../hooks/useActions.ts'
 import { Dashboard, findSubstringMatchRanges, buildServicesText } from '../views/Dashboard.tsx'
 
 const mockConfig: PortConfig = { domain: 'port' }
@@ -64,11 +64,13 @@ const filterWorktrees: WorktreeStatus[] = [
 ]
 
 const noop = () => {}
-const noopAsync = async (): Promise<ActionResult> => ({ success: true, message: '' })
+const noopAction = (): EnqueueResult => ({ accepted: true, jobId: 'job-1' })
 const mockActions = {
-  upWorktree: noopAsync,
-  downWorktree: noopAsync,
-  archiveWorktree: noopAsync,
+  upWorktree: noopAction,
+  downWorktree: noopAction,
+  archiveWorktree: noopAction,
+  isWorktreeBusy: () => false,
+  latestJobByWorktree: new Map(),
 }
 
 /** Common Dashboard props with defaults for testing */

--- a/src/tui/__tests__/Dashboard.test.tsx
+++ b/src/tui/__tests__/Dashboard.test.tsx
@@ -72,6 +72,8 @@ const mockActions = {
   isWorktreeBusy: () => false,
   latestJobByWorktree: new Map(),
   getOutputTail: () => [],
+  isOutputVisible: () => true,
+  toggleOutputVisible: noop,
   cancelWorktreeAction: () => false,
 }
 
@@ -428,8 +430,80 @@ describe('Dashboard', () => {
     const frame = captureCharFrame()
 
     expect(frame).toContain('Output (myapp)')
+    expect(frame).toContain('[l] toggle')
     expect(frame).toContain('Building app...')
     expect(frame).toContain('warning: cache miss')
+  })
+
+  test('l toggles output visibility for selected worktree', async () => {
+    const toggled: string[] = []
+    const tail = [{ stream: 'stdout' as const, line: 'line-1' }]
+
+    const { renderer, mockInput, renderOnce } = await testRender(
+      <Dashboard
+        {...props({
+          actions: {
+            ...mockActions,
+            getOutputTail: () => tail,
+            toggleOutputVisible: (name: string) => toggled.push(name),
+          },
+        })}
+      />,
+      { width: 100, height: 20 }
+    )
+    currentRenderer = renderer
+
+    await renderOnce()
+    await pressAndRender(mockInput, renderOnce, 'l')
+
+    expect(toggled).toEqual(['myapp'])
+  })
+
+  test('hides output section when selected worktree output is toggled off', async () => {
+    const tail = [{ stream: 'stdout' as const, line: 'line-1' }]
+
+    const { renderer, renderOnce, captureCharFrame } = await testRender(
+      <Dashboard
+        {...props({
+          actions: {
+            ...mockActions,
+            getOutputTail: () => tail,
+            isOutputVisible: () => false,
+          },
+        })}
+      />,
+      { width: 100, height: 20 }
+    )
+    currentRenderer = renderer
+
+    await renderOnce()
+    const frame = captureCharFrame()
+    expect(frame).not.toContain('Output (myapp)')
+    expect(frame).not.toContain('line-1')
+  })
+
+  test('respects per-worktree output visibility while switching selection', async () => {
+    const { renderer, mockInput, renderOnce, captureCharFrame } = await testRender(
+      <Dashboard
+        {...props({
+          actions: {
+            ...mockActions,
+            getOutputTail: (name: string) => [{ stream: 'stdout', line: `${name}-output` }],
+            isOutputVisible: (name: string) => name !== 'myapp',
+          },
+        })}
+      />,
+      { width: 100, height: 20 }
+    )
+    currentRenderer = renderer
+
+    await renderOnce()
+    expect(captureCharFrame()).not.toContain('Output (myapp)')
+
+    await pressAndRender(mockInput, renderOnce, 'j')
+    const frame = captureCharFrame()
+    expect(frame).toContain('Output (feature-auth)')
+    expect(frame).toContain('feature-auth-output')
   })
 
   test('shows filter prompt without hiding output lines while filtering', async () => {

--- a/src/tui/__tests__/Dashboard.test.tsx
+++ b/src/tui/__tests__/Dashboard.test.tsx
@@ -225,6 +225,201 @@ describe('Dashboard', () => {
     expect(frame2).toContain('feature-auth')
   })
 
+  test('navigation remains active when selected worktree is busy', async () => {
+    let selectedName = ''
+
+    const { renderer, mockInput, renderOnce } = await testRender(
+      <Dashboard
+        {...props({
+          actions: {
+            ...mockActions,
+            isWorktreeBusy: () => true,
+          },
+          onSelectWorktree: (name: string) => {
+            selectedName = name
+          },
+        })}
+      />,
+      { width: 60, height: 20 }
+    )
+    currentRenderer = renderer
+
+    await renderOnce()
+    await pressAndRender(mockInput, renderOnce, 'j')
+    mockInput.pressEnter()
+    await renderOnce()
+
+    expect(selectedName).toBe('feature-auth')
+  })
+
+  test('u shows error status when action is rejected for busy worktree', async () => {
+    const statusCalls: Array<{ text: string; type: 'success' | 'error' }> = []
+
+    const { renderer, mockInput, renderOnce } = await testRender(
+      <Dashboard
+        {...props({
+          actions: {
+            ...mockActions,
+            upWorktree: () => ({
+              accepted: false,
+              reason: 'worktree_busy',
+              message: 'Action already running for myapp',
+            }),
+          },
+          showStatus: (text: string, type: 'success' | 'error') => {
+            statusCalls.push({ text, type })
+          },
+        })}
+      />,
+      { width: 60, height: 20 }
+    )
+    currentRenderer = renderer
+
+    await renderOnce()
+    await pressAndRender(mockInput, renderOnce, 'u')
+
+    expect(statusCalls).toEqual([{ text: 'Action already running for myapp', type: 'error' }])
+  })
+
+  test('shows running and failed row markers from latest job state', async () => {
+    const { renderer, renderOnce, captureCharFrame } = await testRender(
+      <Dashboard
+        {...props({
+          actions: {
+            ...mockActions,
+            isWorktreeBusy: (name: string) => name === 'myapp',
+            latestJobByWorktree: new Map([
+              [
+                'myapp',
+                {
+                  id: 'job-running',
+                  kind: 'up',
+                  worktreeName: 'myapp',
+                  worktreePath: '/repo',
+                  status: 'running',
+                  summary: 'up',
+                  logs: [],
+                },
+              ],
+              [
+                'feature-auth',
+                {
+                  id: 'job-error',
+                  kind: 'down',
+                  worktreeName: 'feature-auth',
+                  worktreePath: '/repo/.port/trees/feature-auth',
+                  status: 'error',
+                  summary: 'down',
+                  logs: [],
+                },
+              ],
+            ]),
+          },
+        })}
+      />,
+      { width: 90, height: 20 }
+    )
+    currentRenderer = renderer
+
+    await renderOnce()
+    const frame = captureCharFrame()
+
+    expect(frame).toContain('up...')
+    expect(frame).toContain('down failed')
+  })
+
+  test('supports log toggle and job cycling keys', async () => {
+    const toggles: string[] = []
+
+    const { renderer, mockInput, renderOnce } = await testRender(
+      <Dashboard
+        {...props({
+          actions: {
+            ...mockActions,
+            logOpen: true,
+            toggleLog: () => {
+              toggles.push('toggle')
+            },
+            selectPrevLogJob: () => {
+              toggles.push('prev')
+            },
+            selectNextLogJob: () => {
+              toggles.push('next')
+            },
+          },
+        })}
+      />,
+      { width: 80, height: 20 }
+    )
+    currentRenderer = renderer
+
+    await renderOnce()
+    await pressAndRender(mockInput, renderOnce, '[')
+    await pressAndRender(mockInput, renderOnce, ']')
+    await pressAndRender(mockInput, renderOnce, 'l')
+
+    expect(toggles).toEqual(['prev', 'next', 'toggle'])
+  })
+
+  test('shows cancel status error when no running job is selected', async () => {
+    const statusCalls: Array<{ text: string; type: 'success' | 'error' }> = []
+
+    const { renderer, mockInput, renderOnce } = await testRender(
+      <Dashboard
+        {...props({
+          actions: {
+            ...mockActions,
+            logOpen: true,
+            cancelActiveLogJob: () => false,
+          },
+          showStatus: (text: string, type: 'success' | 'error') => {
+            statusCalls.push({ text, type })
+          },
+        })}
+      />,
+      { width: 80, height: 20 }
+    )
+    currentRenderer = renderer
+
+    await renderOnce()
+    await pressAndRender(mockInput, renderOnce, 'c')
+
+    expect(statusCalls).toEqual([{ text: 'No running action selected to cancel', type: 'error' }])
+  })
+
+  test('renders action log panel when log is open', async () => {
+    const activeJob = {
+      id: 'job-1',
+      kind: 'up',
+      worktreeName: 'myapp',
+      worktreePath: '/repo',
+      status: 'running' as const,
+      summary: 'up',
+      logs: [{ ts: 1, stream: 'system' as const, line: 'Starting up' }],
+    }
+
+    const { renderer, renderOnce, captureCharFrame } = await testRender(
+      <Dashboard
+        {...props({
+          actions: {
+            ...mockActions,
+            logOpen: true,
+            jobs: [activeJob],
+            activeLogJob: activeJob,
+          },
+        })}
+      />,
+      { width: 90, height: 24 }
+    )
+    currentRenderer = renderer
+
+    await renderOnce()
+    const frame = captureCharFrame()
+
+    expect(frame).toContain('Action Log')
+    expect(frame).toContain('myapp up running')
+  })
+
   test('Enter calls onSelectWorktree', async () => {
     let selectedName = ''
     const onSelect = (name: string) => {

--- a/src/tui/__tests__/Dashboard.test.tsx
+++ b/src/tui/__tests__/Dashboard.test.tsx
@@ -432,6 +432,34 @@ describe('Dashboard', () => {
     expect(frame).toContain('warning: cache miss')
   })
 
+  test('shows filter prompt without hiding output lines while filtering', async () => {
+    const tail = [
+      { stream: 'stdout' as const, line: 'first output line' },
+      { stream: 'stderr' as const, line: 'second output line' },
+    ]
+
+    const { renderer, mockInput, renderOnce, captureCharFrame } = await testRender(
+      <Dashboard
+        {...props({
+          actions: {
+            ...mockActions,
+            getOutputTail: () => tail,
+          },
+        })}
+      />,
+      { width: 100, height: 24 }
+    )
+    currentRenderer = renderer
+
+    await renderOnce()
+    await pressAndRender(mockInput, renderOnce, '/')
+
+    const frame = captureCharFrame()
+    expect(frame).toContain('(type to filter)')
+    expect(frame).toContain('first output line')
+    expect(frame).toContain('second output line')
+  })
+
   test('shows running and finished output titles with elapsed seconds', async () => {
     const runningJob = {
       id: 'job-running',
@@ -468,7 +496,7 @@ describe('Dashboard', () => {
     )
     currentRenderer = runningRenderer
     await renderRunning()
-    expect(captureRunning()).toContain('Output (myapp) - running')
+    expect(captureRunning()).toContain('Output (myapp) - running for ')
 
     const {
       renderer: finishedRenderer,
@@ -520,6 +548,43 @@ describe('Dashboard', () => {
     await renderOnce()
 
     expect(captureCharFrame()).toContain('Output (myapp) - failed in 4s')
+  })
+
+  test('keeps key hints visible while running output is shown', async () => {
+    const runningJob = {
+      id: 'job-running',
+      kind: 'up' as const,
+      worktreeName: 'myapp',
+      worktreePath: '/repo',
+      status: 'running' as const,
+      summary: 'up',
+      startedAt: 1_000,
+      logs: Array.from({ length: 20 }, (_, index) => ({
+        ts: index + 1,
+        stream: 'stdout' as const,
+        line: `log-${index + 1}`,
+      })),
+    }
+
+    const { renderer, renderOnce, captureCharFrame } = await testRender(
+      <Dashboard
+        {...props({
+          actions: {
+            ...mockActions,
+            isWorktreeBusy: (name: string) => name === 'myapp',
+            latestJobByWorktree: new Map([['myapp', runningJob]]),
+          },
+        })}
+      />,
+      { width: 90, height: 20 }
+    )
+    currentRenderer = renderer
+
+    await renderOnce()
+    const frame = captureCharFrame()
+
+    expect(frame).toContain('Output (myapp) - running for ')
+    expect(frame).toContain('[q]')
   })
 
   test('Enter calls onSelectWorktree', async () => {

--- a/src/tui/__tests__/Dashboard.test.tsx
+++ b/src/tui/__tests__/Dashboard.test.tsx
@@ -77,6 +77,7 @@ const mockActions = {
   toggleLog: noop,
   selectNextLogJob: noop,
   selectPrevLogJob: noop,
+  cancelActiveLogJob: () => false,
 }
 
 /** Common Dashboard props with defaults for testing */

--- a/src/tui/__tests__/Dashboard.test.tsx
+++ b/src/tui/__tests__/Dashboard.test.tsx
@@ -430,7 +430,7 @@ describe('Dashboard', () => {
     const frame = captureCharFrame()
 
     expect(frame).toContain('Output (myapp)')
-    expect(frame).toContain('[l] toggle')
+    expect(frame).toContain('[l] hide')
     expect(frame).toContain('Building app...')
     expect(frame).toContain('warning: cache miss')
   })
@@ -459,7 +459,7 @@ describe('Dashboard', () => {
     expect(toggled).toEqual(['myapp'])
   })
 
-  test('hides output section when selected worktree output is toggled off', async () => {
+  test('shows output placeholder when selected worktree output is toggled off', async () => {
     const tail = [{ stream: 'stdout' as const, line: 'line-1' }]
 
     const { renderer, renderOnce, captureCharFrame } = await testRender(
@@ -478,7 +478,8 @@ describe('Dashboard', () => {
 
     await renderOnce()
     const frame = captureCharFrame()
-    expect(frame).not.toContain('Output (myapp)')
+    expect(frame).toContain('Output (myapp)')
+    expect(frame).toContain('[l] show')
     expect(frame).not.toContain('line-1')
   })
 
@@ -498,7 +499,8 @@ describe('Dashboard', () => {
     currentRenderer = renderer
 
     await renderOnce()
-    expect(captureCharFrame()).not.toContain('Output (myapp)')
+    expect(captureCharFrame()).toContain('Output (myapp)')
+    expect(captureCharFrame()).toContain('[l] show')
 
     await pressAndRender(mockInput, renderOnce, 'j')
     const frame = captureCharFrame()

--- a/src/tui/__tests__/WorktreeView.test.tsx
+++ b/src/tui/__tests__/WorktreeView.test.tsx
@@ -3,7 +3,7 @@ import { testRender } from '@opentui/react/test-utils'
 import type { TestRenderer } from '@opentui/core/testing'
 import type { WorktreeStatus } from '../../lib/worktreeStatus.ts'
 import type { HostService, PortConfig } from '../../types.ts'
-import type { ActionResult } from '../hooks/useActions.ts'
+import type { EnqueueResult } from '../hooks/useActions.ts'
 import { WorktreeView } from '../views/WorktreeView.tsx'
 
 const mockConfig: PortConfig = { domain: 'port' }
@@ -31,10 +31,12 @@ const mockHostServices: HostService[] = [
 ]
 
 const noop = () => {}
-const noopAsync = async (): Promise<ActionResult> => ({ success: true, message: '' })
+const noopAction = (): EnqueueResult => ({ accepted: true, jobId: 'job-1' })
 const mockActions = {
-  downWorktree: noopAsync,
-  killHostService: noopAsync,
+  downWorktree: noopAction,
+  killHostService: noopAction,
+  isWorktreeBusy: () => false,
+  latestJobByWorktree: new Map(),
 }
 
 let currentRenderer: TestRenderer | null = null

--- a/src/tui/__tests__/WorktreeView.test.tsx
+++ b/src/tui/__tests__/WorktreeView.test.tsx
@@ -37,6 +37,12 @@ const mockActions = {
   killHostService: noopAction,
   isWorktreeBusy: () => false,
   latestJobByWorktree: new Map(),
+  jobs: [],
+  logOpen: false,
+  activeLogJob: null,
+  toggleLog: noop,
+  selectNextLogJob: noop,
+  selectPrevLogJob: noop,
 }
 
 let currentRenderer: TestRenderer | null = null

--- a/src/tui/__tests__/WorktreeView.test.tsx
+++ b/src/tui/__tests__/WorktreeView.test.tsx
@@ -525,7 +525,7 @@ describe('WorktreeView', () => {
     )
     currentRenderer = runningRenderer
     await renderRunning()
-    expect(captureRunning()).toContain('Output (feature-auth) - running')
+    expect(captureRunning()).toContain('Output (feature-auth) - running for ')
 
     const {
       renderer: finishedRenderer,

--- a/src/tui/__tests__/WorktreeView.test.tsx
+++ b/src/tui/__tests__/WorktreeView.test.tsx
@@ -273,4 +273,192 @@ describe('WorktreeView', () => {
     expect(serviceLines.length).toBeLessThan(20)
     expect(serviceLines.length).toBeGreaterThan(0)
   })
+
+  test('d shows error status when action is rejected for busy worktree', async () => {
+    const statusCalls: Array<{ text: string; type: 'success' | 'error' }> = []
+
+    const { renderer, mockInput, renderOnce } = await testRender(
+      <WorktreeView
+        worktree={mockWorktree}
+        hostServices={[]}
+        config={mockConfig}
+        repoRoot="/repo"
+        onBack={noop}
+        actions={{
+          ...mockActions,
+          downWorktree: () => ({
+            accepted: false,
+            reason: 'worktree_busy',
+            message: 'Action already running for feature-auth',
+          }),
+        }}
+        refresh={noop}
+        loading={false}
+        statusMessage={null}
+        showStatus={(text: string, type: 'success' | 'error') => statusCalls.push({ text, type })}
+      />,
+      { width: 80, height: 20 }
+    )
+    currentRenderer = renderer
+
+    await renderOnce()
+    mockInput.pressKey('d')
+    await new Promise(resolve => setTimeout(resolve, 50))
+    await renderOnce()
+
+    expect(statusCalls).toEqual([
+      { text: 'Action already running for feature-auth', type: 'error' },
+    ])
+  })
+
+  test('shows running and failed markers from latest job state', async () => {
+    const { renderer, renderOnce, captureCharFrame } = await testRender(
+      <WorktreeView
+        worktree={mockWorktree}
+        hostServices={[]}
+        config={mockConfig}
+        repoRoot="/repo"
+        onBack={noop}
+        actions={{
+          ...mockActions,
+          isWorktreeBusy: () => true,
+          latestJobByWorktree: new Map([
+            [
+              'feature-auth',
+              {
+                id: 'job-running',
+                kind: 'down',
+                worktreeName: 'feature-auth',
+                worktreePath: '/repo/.port/trees/feature-auth',
+                status: 'running',
+                summary: 'down',
+                logs: [],
+              },
+            ],
+          ]),
+        }}
+        refresh={noop}
+        loading={false}
+        statusMessage={null}
+        showStatus={noop}
+      />,
+      { width: 80, height: 20 }
+    )
+    currentRenderer = renderer
+
+    await renderOnce()
+    const frame = captureCharFrame()
+    expect(frame).toContain('down...')
+  })
+
+  test('supports log toggle and job cycling keys', async () => {
+    const calls: string[] = []
+
+    const { renderer, mockInput, renderOnce } = await testRender(
+      <WorktreeView
+        worktree={mockWorktree}
+        hostServices={[]}
+        config={mockConfig}
+        repoRoot="/repo"
+        onBack={noop}
+        actions={{
+          ...mockActions,
+          logOpen: true,
+          toggleLog: () => calls.push('toggle'),
+          selectPrevLogJob: () => calls.push('prev'),
+          selectNextLogJob: () => calls.push('next'),
+        }}
+        refresh={noop}
+        loading={false}
+        statusMessage={null}
+        showStatus={noop}
+      />,
+      { width: 90, height: 20 }
+    )
+    currentRenderer = renderer
+
+    await renderOnce()
+    mockInput.pressKey('[')
+    await new Promise(resolve => setTimeout(resolve, 50))
+    await renderOnce()
+    mockInput.pressKey(']')
+    await new Promise(resolve => setTimeout(resolve, 50))
+    await renderOnce()
+    mockInput.pressKey('l')
+    await new Promise(resolve => setTimeout(resolve, 50))
+    await renderOnce()
+
+    expect(calls).toEqual(['prev', 'next', 'toggle'])
+  })
+
+  test('shows cancel status error when no running job is selected', async () => {
+    const statusCalls: Array<{ text: string; type: 'success' | 'error' }> = []
+
+    const { renderer, mockInput, renderOnce } = await testRender(
+      <WorktreeView
+        worktree={mockWorktree}
+        hostServices={[]}
+        config={mockConfig}
+        repoRoot="/repo"
+        onBack={noop}
+        actions={{
+          ...mockActions,
+          logOpen: true,
+          cancelActiveLogJob: () => false,
+        }}
+        refresh={noop}
+        loading={false}
+        statusMessage={null}
+        showStatus={(text: string, type: 'success' | 'error') => statusCalls.push({ text, type })}
+      />,
+      { width: 90, height: 20 }
+    )
+    currentRenderer = renderer
+
+    await renderOnce()
+    mockInput.pressKey('c')
+    await new Promise(resolve => setTimeout(resolve, 50))
+    await renderOnce()
+
+    expect(statusCalls).toEqual([{ text: 'No running action selected to cancel', type: 'error' }])
+  })
+
+  test('renders action log panel when log is open', async () => {
+    const activeJob = {
+      id: 'job-1',
+      kind: 'down' as const,
+      worktreeName: 'feature-auth',
+      worktreePath: '/repo/.port/trees/feature-auth',
+      status: 'running' as const,
+      summary: 'down',
+      logs: [{ ts: 1, stream: 'system' as const, line: 'Stopping services' }],
+    }
+
+    const { renderer, renderOnce, captureCharFrame } = await testRender(
+      <WorktreeView
+        worktree={mockWorktree}
+        hostServices={[]}
+        config={mockConfig}
+        repoRoot="/repo"
+        onBack={noop}
+        actions={{
+          ...mockActions,
+          logOpen: true,
+          jobs: [activeJob],
+          activeLogJob: activeJob,
+        }}
+        refresh={noop}
+        loading={false}
+        statusMessage={null}
+        showStatus={noop}
+      />,
+      { width: 90, height: 22 }
+    )
+    currentRenderer = renderer
+
+    await renderOnce()
+    const frame = captureCharFrame()
+    expect(frame).toContain('Action Log')
+    expect(frame).toContain('feature-auth down running')
+  })
 })

--- a/src/tui/__tests__/WorktreeView.test.tsx
+++ b/src/tui/__tests__/WorktreeView.test.tsx
@@ -43,6 +43,7 @@ const mockActions = {
   toggleLog: noop,
   selectNextLogJob: noop,
   selectPrevLogJob: noop,
+  cancelActiveLogJob: () => false,
 }
 
 let currentRenderer: TestRenderer | null = null

--- a/src/tui/__tests__/WorktreeView.test.tsx
+++ b/src/tui/__tests__/WorktreeView.test.tsx
@@ -38,6 +38,8 @@ const mockActions = {
   isWorktreeBusy: () => false,
   latestJobByWorktree: new Map(),
   getOutputTail: () => [],
+  isOutputVisible: () => true,
+  toggleOutputVisible: noop,
   cancelWorktreeAction: () => false,
 }
 
@@ -478,8 +480,69 @@ describe('WorktreeView', () => {
     await renderOnce()
     const frame = captureCharFrame()
     expect(frame).toContain('Output (feature-auth)')
+    expect(frame).toContain('[l] toggle')
     expect(frame).toContain('Stopping services...')
     expect(frame).toContain('warning: network busy')
+  })
+
+  test('l toggles output visibility for current worktree', async () => {
+    const toggled: string[] = []
+
+    const { renderer, mockInput, renderOnce } = await testRender(
+      <WorktreeView
+        worktree={mockWorktree}
+        hostServices={[]}
+        config={mockConfig}
+        repoRoot="/repo"
+        onBack={noop}
+        actions={{
+          ...mockActions,
+          getOutputTail: () => [{ stream: 'stdout', line: 'line-1' }],
+          toggleOutputVisible: (name: string) => toggled.push(name),
+        }}
+        refresh={noop}
+        loading={false}
+        statusMessage={null}
+        showStatus={noop}
+      />,
+      { width: 90, height: 22 }
+    )
+    currentRenderer = renderer
+
+    await renderOnce()
+    mockInput.pressKey('l')
+    await new Promise(resolve => setTimeout(resolve, 50))
+    await renderOnce()
+
+    expect(toggled).toEqual(['feature-auth'])
+  })
+
+  test('hides output section when visibility is off for worktree', async () => {
+    const { renderer, renderOnce, captureCharFrame } = await testRender(
+      <WorktreeView
+        worktree={mockWorktree}
+        hostServices={[]}
+        config={mockConfig}
+        repoRoot="/repo"
+        onBack={noop}
+        actions={{
+          ...mockActions,
+          isOutputVisible: () => false,
+          getOutputTail: () => [{ stream: 'stdout', line: 'line-1' }],
+        }}
+        refresh={noop}
+        loading={false}
+        statusMessage={null}
+        showStatus={noop}
+      />,
+      { width: 90, height: 22 }
+    )
+    currentRenderer = renderer
+
+    await renderOnce()
+    const frame = captureCharFrame()
+    expect(frame).not.toContain('Output (feature-auth)')
+    expect(frame).not.toContain('line-1')
   })
 
   test('shows running and finished output titles with elapsed seconds', async () => {

--- a/src/tui/__tests__/WorktreeView.test.tsx
+++ b/src/tui/__tests__/WorktreeView.test.tsx
@@ -37,13 +37,8 @@ const mockActions = {
   killHostService: noopAction,
   isWorktreeBusy: () => false,
   latestJobByWorktree: new Map(),
-  jobs: [],
-  logOpen: false,
-  activeLogJob: null,
-  toggleLog: noop,
-  selectNextLogJob: noop,
-  selectPrevLogJob: noop,
-  cancelActiveLogJob: () => false,
+  getOutputTail: () => [],
+  cancelWorktreeAction: () => false,
 }
 
 let currentRenderer: TestRenderer | null = null
@@ -194,9 +189,47 @@ describe('WorktreeView', () => {
 
     expect(frame).toContain('[Enter]')
     expect(frame).toContain('[d]')
-    expect(frame).toContain('[Esc]')
-    expect(frame).toContain('[r]')
-    expect(frame).toContain('[q]')
+    expect(frame).toContain('[x]')
+    expect(frame).not.toContain('[c]')
+  })
+
+  test('shows cancel hint only while current worktree action is running', async () => {
+    const { renderer, renderOnce, captureCharFrame } = await testRender(
+      <WorktreeView
+        worktree={mockWorktree}
+        hostServices={[]}
+        config={mockConfig}
+        repoRoot="/repo"
+        onBack={noop}
+        actions={{
+          ...mockActions,
+          isWorktreeBusy: () => true,
+          latestJobByWorktree: new Map([
+            [
+              'feature-auth',
+              {
+                id: 'job-running',
+                kind: 'down',
+                worktreeName: 'feature-auth',
+                worktreePath: '/repo/.port/trees/feature-auth',
+                status: 'running',
+                summary: 'down',
+                logs: [],
+              },
+            ],
+          ]),
+        }}
+        refresh={noop}
+        loading={false}
+        statusMessage={null}
+        showStatus={noop}
+      />,
+      { width: 100, height: 20 }
+    )
+    currentRenderer = renderer
+
+    await renderOnce()
+    expect(captureCharFrame()).toContain('[c]')
   })
 
   test('shows no services message when empty', async () => {
@@ -351,7 +384,7 @@ describe('WorktreeView', () => {
     expect(frame).toContain('down...')
   })
 
-  test('supports log toggle and job cycling keys', async () => {
+  test('c triggers cancellation for current worktree', async () => {
     const calls: string[] = []
 
     const { renderer, mockInput, renderOnce } = await testRender(
@@ -363,10 +396,10 @@ describe('WorktreeView', () => {
         onBack={noop}
         actions={{
           ...mockActions,
-          logOpen: true,
-          toggleLog: () => calls.push('toggle'),
-          selectPrevLogJob: () => calls.push('prev'),
-          selectNextLogJob: () => calls.push('next'),
+          cancelWorktreeAction: (name: string) => {
+            calls.push(name)
+            return true
+          },
         }}
         refresh={noop}
         loading={false}
@@ -378,17 +411,11 @@ describe('WorktreeView', () => {
     currentRenderer = renderer
 
     await renderOnce()
-    mockInput.pressKey('[')
-    await new Promise(resolve => setTimeout(resolve, 50))
-    await renderOnce()
-    mockInput.pressKey(']')
-    await new Promise(resolve => setTimeout(resolve, 50))
-    await renderOnce()
-    mockInput.pressKey('l')
+    mockInput.pressKey('c')
     await new Promise(resolve => setTimeout(resolve, 50))
     await renderOnce()
 
-    expect(calls).toEqual(['prev', 'next', 'toggle'])
+    expect(calls).toEqual(['feature-auth'])
   })
 
   test('shows cancel status error when no running job is selected', async () => {
@@ -403,8 +430,7 @@ describe('WorktreeView', () => {
         onBack={noop}
         actions={{
           ...mockActions,
-          logOpen: true,
-          cancelActiveLogJob: () => false,
+          cancelWorktreeAction: () => false,
         }}
         refresh={noop}
         loading={false}
@@ -423,16 +449,11 @@ describe('WorktreeView', () => {
     expect(statusCalls).toEqual([{ text: 'No running action selected to cancel', type: 'error' }])
   })
 
-  test('renders action log panel when log is open', async () => {
-    const activeJob = {
-      id: 'job-1',
-      kind: 'down' as const,
-      worktreeName: 'feature-auth',
-      worktreePath: '/repo/.port/trees/feature-auth',
-      status: 'running' as const,
-      summary: 'down',
-      logs: [{ ts: 1, stream: 'system' as const, line: 'Stopping services' }],
-    }
+  test('renders two-line output tail', async () => {
+    const tail = [
+      { stream: 'stdout' as const, line: 'Stopping services...' },
+      { stream: 'stderr' as const, line: 'warning: network busy' },
+    ]
 
     const { renderer, renderOnce, captureCharFrame } = await testRender(
       <WorktreeView
@@ -443,9 +464,7 @@ describe('WorktreeView', () => {
         onBack={noop}
         actions={{
           ...mockActions,
-          logOpen: true,
-          jobs: [activeJob],
-          activeLogJob: activeJob,
+          getOutputTail: () => tail,
         }}
         refresh={noop}
         loading={false}
@@ -458,7 +477,119 @@ describe('WorktreeView', () => {
 
     await renderOnce()
     const frame = captureCharFrame()
-    expect(frame).toContain('Action Log')
-    expect(frame).toContain('feature-auth down running')
+    expect(frame).toContain('Output (feature-auth)')
+    expect(frame).toContain('Stopping services...')
+    expect(frame).toContain('warning: network busy')
+  })
+
+  test('shows running and finished output titles with elapsed seconds', async () => {
+    const runningJob = {
+      id: 'job-running',
+      kind: 'down' as const,
+      worktreeName: 'feature-auth',
+      worktreePath: '/repo/.port/trees/feature-auth',
+      status: 'running' as const,
+      summary: 'down',
+      startedAt: 500,
+      logs: [],
+    }
+    const finishedJob = {
+      ...runningJob,
+      id: 'job-finished',
+      status: 'success' as const,
+      endedAt: 3_000,
+    }
+
+    const {
+      renderer: runningRenderer,
+      renderOnce: renderRunning,
+      captureCharFrame: captureRunning,
+    } = await testRender(
+      <WorktreeView
+        worktree={mockWorktree}
+        hostServices={[]}
+        config={mockConfig}
+        repoRoot="/repo"
+        onBack={noop}
+        actions={{
+          ...mockActions,
+          isWorktreeBusy: () => true,
+          latestJobByWorktree: new Map([['feature-auth', runningJob]]),
+        }}
+        refresh={noop}
+        loading={false}
+        statusMessage={null}
+        showStatus={noop}
+      />,
+      { width: 110, height: 22 }
+    )
+    currentRenderer = runningRenderer
+    await renderRunning()
+    expect(captureRunning()).toContain('Output (feature-auth) - running')
+
+    const {
+      renderer: finishedRenderer,
+      renderOnce: renderFinished,
+      captureCharFrame: captureFinished,
+    } = await testRender(
+      <WorktreeView
+        worktree={mockWorktree}
+        hostServices={[]}
+        config={mockConfig}
+        repoRoot="/repo"
+        onBack={noop}
+        actions={{
+          ...mockActions,
+          latestJobByWorktree: new Map([['feature-auth', finishedJob]]),
+          getOutputTail: () => [{ stream: 'stdout', line: 'done' }],
+        }}
+        refresh={noop}
+        loading={false}
+        statusMessage={null}
+        showStatus={noop}
+      />,
+      { width: 110, height: 22 }
+    )
+    currentRenderer = finishedRenderer
+    await renderFinished()
+    expect(captureFinished()).toContain('Output (feature-auth) - finished in 3s')
+  })
+
+  test('shows failure-specific output title wording', async () => {
+    const failedJob = {
+      id: 'job-failed',
+      kind: 'down' as const,
+      worktreeName: 'feature-auth',
+      worktreePath: '/repo/.port/trees/feature-auth',
+      status: 'error' as const,
+      summary: 'down',
+      startedAt: 1_000,
+      endedAt: 5_900,
+      logs: [],
+    }
+
+    const { renderer, renderOnce, captureCharFrame } = await testRender(
+      <WorktreeView
+        worktree={mockWorktree}
+        hostServices={[]}
+        config={mockConfig}
+        repoRoot="/repo"
+        onBack={noop}
+        actions={{
+          ...mockActions,
+          latestJobByWorktree: new Map([['feature-auth', failedJob]]),
+          getOutputTail: () => [{ stream: 'stderr', line: 'failed' }],
+        }}
+        refresh={noop}
+        loading={false}
+        statusMessage={null}
+        showStatus={noop}
+      />,
+      { width: 110, height: 22 }
+    )
+    currentRenderer = renderer
+    await renderOnce()
+
+    expect(captureCharFrame()).toContain('Output (feature-auth) - failed in 5s')
   })
 })

--- a/src/tui/__tests__/WorktreeView.test.tsx
+++ b/src/tui/__tests__/WorktreeView.test.tsx
@@ -480,7 +480,7 @@ describe('WorktreeView', () => {
     await renderOnce()
     const frame = captureCharFrame()
     expect(frame).toContain('Output (feature-auth)')
-    expect(frame).toContain('[l] toggle')
+    expect(frame).toContain('[l] hide')
     expect(frame).toContain('Stopping services...')
     expect(frame).toContain('warning: network busy')
   })
@@ -517,7 +517,7 @@ describe('WorktreeView', () => {
     expect(toggled).toEqual(['feature-auth'])
   })
 
-  test('hides output section when visibility is off for worktree', async () => {
+  test('shows output placeholder when visibility is off for worktree', async () => {
     const { renderer, renderOnce, captureCharFrame } = await testRender(
       <WorktreeView
         worktree={mockWorktree}
@@ -541,7 +541,8 @@ describe('WorktreeView', () => {
 
     await renderOnce()
     const frame = captureCharFrame()
-    expect(frame).not.toContain('Output (feature-auth)')
+    expect(frame).toContain('Output (feature-auth)')
+    expect(frame).toContain('[l] show')
     expect(frame).not.toContain('line-1')
   })
 

--- a/src/tui/__tests__/WorktreeView.test.tsx
+++ b/src/tui/__tests__/WorktreeView.test.tsx
@@ -485,6 +485,34 @@ describe('WorktreeView', () => {
     expect(frame).toContain('warning: network busy')
   })
 
+  test('renders output section below services', async () => {
+    const { renderer, renderOnce, captureCharFrame } = await testRender(
+      <WorktreeView
+        worktree={mockWorktree}
+        hostServices={mockHostServices}
+        config={mockConfig}
+        repoRoot="/repo"
+        onBack={noop}
+        actions={{
+          ...mockActions,
+          getOutputTail: () => [{ stream: 'stdout', line: 'post-services-output' }],
+        }}
+        refresh={noop}
+        loading={false}
+        statusMessage={null}
+        showStatus={noop}
+      />,
+      { width: 100, height: 24 }
+    )
+    currentRenderer = renderer
+
+    await renderOnce()
+    const frame = captureCharFrame()
+
+    expect(frame.indexOf('Docker Services')).toBeGreaterThanOrEqual(0)
+    expect(frame.indexOf('Output (feature-auth)')).toBeGreaterThan(frame.indexOf('Docker Services'))
+  })
+
   test('l toggles output visibility for current worktree', async () => {
     const toggled: string[] = []
 

--- a/src/tui/components/ActionLog.tsx
+++ b/src/tui/components/ActionLog.tsx
@@ -1,0 +1,73 @@
+import type { ActionJob } from '../hooks/useActions.ts'
+
+interface ActionLogProps {
+  jobs: ActionJob[]
+  activeJob: ActionJob | null
+}
+
+function renderStatus(status: ActionJob['status']): string {
+  switch (status) {
+    case 'queued':
+      return 'queued'
+    case 'running':
+      return 'running'
+    case 'success':
+      return 'success'
+    case 'cancelled':
+      return 'cancelled'
+    case 'error':
+      return 'error'
+  }
+}
+
+function statusColor(status: ActionJob['status']): string {
+  switch (status) {
+    case 'running':
+      return '#FFFF00'
+    case 'success':
+      return '#00FF00'
+    case 'error':
+      return '#FF4444'
+    case 'cancelled':
+      return '#FFAA00'
+    default:
+      return '#888888'
+  }
+}
+
+export function ActionLog({ jobs, activeJob }: ActionLogProps) {
+  const recentJobs = jobs.slice(0, 3)
+  const activeLogs = activeJob?.logs.slice(-4) ?? []
+
+  return (
+    <box flexDirection="column" gap={1}>
+      <text fg="#888888">
+        <b>Action Log</b>
+      </text>
+
+      {recentJobs.length === 0 && <text fg="#666666">No actions yet</text>}
+
+      {recentJobs.map(job => (
+        <box key={job.id} flexDirection="row" gap={1}>
+          <text>{activeJob?.id === job.id ? '>' : ' '}</text>
+          <text fg="#CCCCCC">{job.worktreeName}</text>
+          <text fg="#888888">{job.kind}</text>
+          <text fg={statusColor(job.status)}>{renderStatus(job.status)}</text>
+        </box>
+      ))}
+
+      {activeJob && activeLogs.length > 0 && (
+        <box flexDirection="column" gap={0}>
+          {activeLogs.map((entry, index) => (
+            <text
+              key={`${activeJob.id}-line-${index}`}
+              fg={entry.stream === 'stderr' ? '#FF8888' : '#888888'}
+            >
+              {entry.line}
+            </text>
+          ))}
+        </box>
+      )}
+    </box>
+  )
+}

--- a/src/tui/components/KeyHints.tsx
+++ b/src/tui/components/KeyHints.tsx
@@ -9,11 +9,13 @@ interface KeyHintsProps {
 
 export function KeyHints({ hints }: KeyHintsProps) {
   return (
-    <box flexDirection="row" gap={2}>
+    <box flexDirection="row" flexWrap="wrap" columnGap={2} rowGap={0}>
       {hints.map(hint => (
-        <text key={hint.key} fg="#888888">
-          <b fg="#CCCCCC">[{hint.key}]</b> {hint.action}
-        </text>
+        <box key={`${hint.key}-${hint.action}`} flexShrink={0}>
+          <text fg="#888888">
+            <b fg="#CCCCCC">[{hint.key}]</b> {hint.action}
+          </text>
+        </box>
       ))}
     </box>
   )

--- a/src/tui/hooks/useActions.state.test.ts
+++ b/src/tui/hooks/useActions.state.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, test } from 'bun:test'
+import { describe, expect, test } from 'vitest'
 import {
   INITIAL_ACTION_STATE,
   createEnqueueDecision,

--- a/src/tui/hooks/useActions.state.test.ts
+++ b/src/tui/hooks/useActions.state.test.ts
@@ -162,6 +162,29 @@ describe('reduceActionState', () => {
     expect(trimmed.runningByWorktree['old']).toBeUndefined()
     expect(trimmed.runningByWorktree['new']).toBe('job-new')
   })
+
+  test('tracks per-worktree output visibility and auto-shows on enqueue', () => {
+    const job = makeJob({ id: 'job-1', worktreeName: 'feature-a' })
+    const queued = reduceActionState(INITIAL_ACTION_STATE, { type: 'enqueue', job })
+    expect(queued.outputVisibleByWorktree['feature-a']).toBe(true)
+
+    const hidden = reduceActionState(queued, {
+      type: 'toggle-output-visible',
+      worktreeName: 'feature-a',
+    })
+    expect(hidden.outputVisibleByWorktree['feature-a']).toBe(false)
+
+    const shown = reduceActionState(hidden, {
+      type: 'set-output-visible',
+      worktreeName: 'feature-a',
+      visible: true,
+    })
+    expect(shown.outputVisibleByWorktree['feature-a']).toBe(true)
+
+    const nextJob = makeJob({ id: 'job-2', worktreeName: 'feature-a' })
+    const autoShown = reduceActionState(shown, { type: 'enqueue', job: nextJob })
+    expect(autoShown.outputVisibleByWorktree['feature-a']).toBe(true)
+  })
 })
 
 describe('waitForRunningActionsToDrain', () => {

--- a/src/tui/hooks/useActions.state.test.ts
+++ b/src/tui/hooks/useActions.state.test.ts
@@ -3,6 +3,7 @@ import {
   INITIAL_ACTION_STATE,
   createEnqueueDecision,
   reduceActionState,
+  waitForRunningActionsToDrain,
   type ActionJob,
   type ActionState,
 } from './useActions.ts'
@@ -160,5 +161,42 @@ describe('reduceActionState', () => {
     expect(trimmed.jobs['job-new']?.logs).toEqual([{ ts: 4, stream: 'system', line: 'line-4' }])
     expect(trimmed.runningByWorktree['old']).toBeUndefined()
     expect(trimmed.runningByWorktree['new']).toBe('job-new')
+  })
+})
+
+describe('waitForRunningActionsToDrain', () => {
+  test('resolves when running actions drain before timeout', async () => {
+    let state: ActionState = {
+      ...INITIAL_ACTION_STATE,
+      runningByWorktree: { 'feature-a': 'job-a' },
+    }
+
+    const resultPromise = waitForRunningActionsToDrain({
+      getState: () => state,
+      timeoutMs: 100,
+      intervalMs: 1,
+      sleep: async () => {
+        state = { ...state, runningByWorktree: {} }
+      },
+    })
+
+    const result = await resultPromise
+    expect(result).toEqual({ timedOut: false, remaining: 0 })
+  })
+
+  test('returns timeout when running actions do not drain', async () => {
+    const state: ActionState = {
+      ...INITIAL_ACTION_STATE,
+      runningByWorktree: { 'feature-a': 'job-a' },
+    }
+
+    const result = await waitForRunningActionsToDrain({
+      getState: () => state,
+      timeoutMs: 0,
+      intervalMs: 1,
+      sleep: async () => {},
+    })
+
+    expect(result).toEqual({ timedOut: true, remaining: 1 })
   })
 })

--- a/src/tui/hooks/useActions.state.test.ts
+++ b/src/tui/hooks/useActions.state.test.ts
@@ -99,20 +99,36 @@ describe('reduceActionState', () => {
     expect(finished.runningByWorktree['feature-a']).toBeUndefined()
   })
 
-  test('cycles active log job with next/prev events', () => {
-    const first = makeJob({ id: 'job-1', worktreeName: 'one' })
-    const second = makeJob({ id: 'job-2', worktreeName: 'two' })
+  test('tracks only the last two streamed output lines per worktree', () => {
+    const job = makeJob({ id: 'job-1', worktreeName: 'feature-a' })
 
-    const stateAfterJobs = reduceActionState(
-      reduceActionState(INITIAL_ACTION_STATE, { type: 'enqueue', job: first }),
-      { type: 'enqueue', job: second }
-    )
+    const queued = reduceActionState(INITIAL_ACTION_STATE, { type: 'enqueue', job })
+    const afterOne = reduceActionState(queued, {
+      type: 'log',
+      jobId: 'job-1',
+      stream: 'stdout',
+      line: 'line-1',
+      ts: 1,
+    })
+    const afterTwo = reduceActionState(afterOne, {
+      type: 'log',
+      jobId: 'job-1',
+      stream: 'stderr',
+      line: 'line-2',
+      ts: 2,
+    })
+    const afterThree = reduceActionState(afterTwo, {
+      type: 'log',
+      jobId: 'job-1',
+      stream: 'stdout',
+      line: 'line-3',
+      ts: 3,
+    })
 
-    const next = reduceActionState(stateAfterJobs, { type: 'next-log-job' })
-    expect(next.activeLogJobId).toBe('job-2')
-
-    const prev = reduceActionState(next, { type: 'prev-log-job' })
-    expect(prev.activeLogJobId).toBe('job-1')
+    expect(afterThree.outputTailByWorktree['feature-a']).toEqual([
+      { stream: 'stderr', line: 'line-2' },
+      { stream: 'stdout', line: 'line-3' },
+    ])
   })
 
   test('trims old jobs and log lines', () => {

--- a/src/tui/hooks/useActions.state.test.ts
+++ b/src/tui/hooks/useActions.state.test.ts
@@ -1,0 +1,148 @@
+import { describe, expect, test } from 'bun:test'
+import {
+  INITIAL_ACTION_STATE,
+  createEnqueueDecision,
+  reduceActionState,
+  type ActionJob,
+  type ActionState,
+} from './useActions.ts'
+
+function makeJob(partial: Partial<ActionJob> & Pick<ActionJob, 'id' | 'worktreeName'>): ActionJob {
+  return {
+    id: partial.id,
+    kind: partial.kind ?? 'up',
+    worktreeName: partial.worktreeName,
+    worktreePath: partial.worktreePath ?? `/repo/.port/trees/${partial.worktreeName}`,
+    status: partial.status ?? 'queued',
+    summary: partial.summary ?? `job ${partial.id}`,
+    startedAt: partial.startedAt,
+    endedAt: partial.endedAt,
+    error: partial.error,
+    logs: partial.logs ?? [],
+  }
+}
+
+describe('createEnqueueDecision', () => {
+  test('rejects second action on same worktree', () => {
+    const state: ActionState = {
+      ...INITIAL_ACTION_STATE,
+      runningByWorktree: { 'feature-a': 'job-a' },
+    }
+
+    const result = createEnqueueDecision({
+      state,
+      kind: 'down',
+      worktreePath: '/repo/.port/trees/feature-a',
+      worktreeName: 'feature-a',
+      summary: 'stop feature-a',
+    })
+
+    expect(result).toEqual({
+      accepted: false,
+      reason: 'worktree_busy',
+      message: 'Action already running for feature-a',
+    })
+  })
+
+  test('allows concurrent actions on different worktrees', () => {
+    const state: ActionState = {
+      ...INITIAL_ACTION_STATE,
+      runningByWorktree: { 'feature-a': 'job-a' },
+    }
+
+    const result = createEnqueueDecision({
+      state,
+      kind: 'down',
+      worktreePath: '/repo/.port/trees/feature-b',
+      worktreeName: 'feature-b',
+      summary: 'stop feature-b',
+    })
+
+    expect(result.accepted).toBe(true)
+    if (result.accepted) {
+      expect(result.job.worktreeName).toBe('feature-b')
+      expect(result.job.kind).toBe('down')
+      expect(result.job.status).toBe('queued')
+    }
+  })
+})
+
+describe('reduceActionState', () => {
+  test('handles enqueue/start/log/finish transition sequence', () => {
+    const job = makeJob({ id: 'job-1', worktreeName: 'feature-a' })
+
+    const queued = reduceActionState(INITIAL_ACTION_STATE, { type: 'enqueue', job })
+    expect(queued.order).toEqual(['job-1'])
+    expect(queued.runningByWorktree['feature-a']).toBe('job-1')
+
+    const running = reduceActionState(queued, { type: 'start', jobId: 'job-1', startedAt: 100 })
+    expect(running.jobs['job-1']?.status).toBe('running')
+    expect(running.jobs['job-1']?.startedAt).toBe(100)
+
+    const logged = reduceActionState(running, {
+      type: 'log',
+      jobId: 'job-1',
+      stream: 'stdout',
+      line: 'hello',
+      ts: 101,
+    })
+    expect(logged.jobs['job-1']?.logs).toEqual([{ ts: 101, stream: 'stdout', line: 'hello' }])
+
+    const finished = reduceActionState(logged, {
+      type: 'finish',
+      jobId: 'job-1',
+      status: 'success',
+      endedAt: 102,
+    })
+    expect(finished.jobs['job-1']?.status).toBe('success')
+    expect(finished.jobs['job-1']?.endedAt).toBe(102)
+    expect(finished.runningByWorktree['feature-a']).toBeUndefined()
+  })
+
+  test('cycles active log job with next/prev events', () => {
+    const first = makeJob({ id: 'job-1', worktreeName: 'one' })
+    const second = makeJob({ id: 'job-2', worktreeName: 'two' })
+
+    const stateAfterJobs = reduceActionState(
+      reduceActionState(INITIAL_ACTION_STATE, { type: 'enqueue', job: first }),
+      { type: 'enqueue', job: second }
+    )
+
+    const next = reduceActionState(stateAfterJobs, { type: 'next-log-job' })
+    expect(next.activeLogJobId).toBe('job-2')
+
+    const prev = reduceActionState(next, { type: 'prev-log-job' })
+    expect(prev.activeLogJobId).toBe('job-1')
+  })
+
+  test('trims old jobs and log lines', () => {
+    const oldJob = makeJob({
+      id: 'job-old',
+      worktreeName: 'old',
+      logs: [
+        { ts: 1, stream: 'system', line: 'line-1' },
+        { ts: 2, stream: 'system', line: 'line-2' },
+      ],
+    })
+    const newJob = makeJob({
+      id: 'job-new',
+      worktreeName: 'new',
+      logs: [
+        { ts: 3, stream: 'system', line: 'line-3' },
+        { ts: 4, stream: 'system', line: 'line-4' },
+      ],
+    })
+
+    const queued = reduceActionState(
+      reduceActionState(INITIAL_ACTION_STATE, { type: 'enqueue', job: oldJob }),
+      { type: 'enqueue', job: newJob }
+    )
+
+    const trimmed = reduceActionState(queued, { type: 'trim', maxJobs: 1, maxLinesPerJob: 1 })
+    expect(trimmed.order).toEqual(['job-new'])
+    expect(Object.keys(trimmed.jobs)).toEqual(['job-new'])
+    expect(trimmed.jobs['job-new']?.logs).toEqual([{ ts: 4, stream: 'system', line: 'line-4' }])
+    expect(trimmed.runningByWorktree['old']).toBeUndefined()
+    expect(trimmed.runningByWorktree['new']).toBe('job-new')
+  })
+})

--- a/src/tui/hooks/useActions.state.test.ts
+++ b/src/tui/hooks/useActions.state.test.ts
@@ -185,6 +185,46 @@ describe('reduceActionState', () => {
     const autoShown = reduceActionState(shown, { type: 'enqueue', job: nextJob })
     expect(autoShown.outputVisibleByWorktree['feature-a']).toBe(true)
   })
+
+  test('auto-hides output on all terminal outcomes', () => {
+    const base = reduceActionState(INITIAL_ACTION_STATE, {
+      type: 'enqueue',
+      job: makeJob({ id: 'job-1', worktreeName: 'feature-a' }),
+    })
+
+    const success = reduceActionState(base, {
+      type: 'finish',
+      jobId: 'job-1',
+      status: 'success',
+      endedAt: 10,
+    })
+    expect(success.outputVisibleByWorktree['feature-a']).toBe(false)
+
+    const baseError = reduceActionState(INITIAL_ACTION_STATE, {
+      type: 'enqueue',
+      job: makeJob({ id: 'job-2', worktreeName: 'feature-b' }),
+    })
+    const error = reduceActionState(baseError, {
+      type: 'finish',
+      jobId: 'job-2',
+      status: 'error',
+      endedAt: 10,
+      error: 'boom',
+    })
+    expect(error.outputVisibleByWorktree['feature-b']).toBe(false)
+
+    const baseCancelled = reduceActionState(INITIAL_ACTION_STATE, {
+      type: 'enqueue',
+      job: makeJob({ id: 'job-3', worktreeName: 'feature-c' }),
+    })
+    const cancelled = reduceActionState(baseCancelled, {
+      type: 'finish',
+      jobId: 'job-3',
+      status: 'cancelled',
+      endedAt: 10,
+    })
+    expect(cancelled.outputVisibleByWorktree['feature-c']).toBe(false)
+  })
 })
 
 describe('waitForRunningActionsToDrain', () => {

--- a/src/tui/hooks/useActions.ts
+++ b/src/tui/hooks/useActions.ts
@@ -1,4 +1,4 @@
-import { useCallback, useMemo, useReducer, useRef } from 'react'
+import { useCallback, useEffect, useMemo, useReducer, useRef } from 'react'
 import type { PortConfig, HostService } from '../../types.ts'
 import { getComposeFile } from '../../lib/config.ts'
 import {
@@ -63,6 +63,12 @@ interface EnqueueRejected {
 }
 
 export type EnqueueResult = EnqueueSuccess | EnqueueRejected
+
+export interface ShutdownJobsResult {
+  cancelledCount: number
+  timedOut: boolean
+  remaining: number
+}
 
 export interface ActionState {
   order: string[]
@@ -267,11 +273,44 @@ function createJobId(kind: ActionKind, worktreeName: string): string {
   return `${kind}-${worktreeName}-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`
 }
 
+export async function waitForRunningActionsToDrain(options: {
+  getState: () => ActionState
+  timeoutMs: number
+  intervalMs?: number
+  sleep?: (ms: number) => Promise<void>
+}): Promise<{ timedOut: boolean; remaining: number }> {
+  const intervalMs = options.intervalMs ?? 50
+  const sleep =
+    options.sleep ??
+    (async (ms: number) => {
+      await new Promise(resolve => setTimeout(resolve, ms))
+    })
+
+  const startedAt = Date.now()
+  while (true) {
+    const remainingCount = Object.keys(options.getState().runningByWorktree).length
+    if (remainingCount === 0) {
+      return { timedOut: false, remaining: 0 }
+    }
+
+    if (Date.now() - startedAt >= options.timeoutMs) {
+      return { timedOut: true, remaining: remainingCount }
+    }
+
+    await sleep(intervalMs)
+  }
+}
+
 export function useActions(repoRoot: string, config: PortConfig, refresh: () => void) {
   const composeFile = getComposeFile(config)
   const [state, dispatch] = useReducer(reduceActionState, INITIAL_ACTION_STATE)
+  const stateRef = useRef(state)
   const controllersRef = useRef(new Map<string, AbortController>())
   const infraLockRef = useRef<Promise<void>>(Promise.resolve())
+
+  useEffect(() => {
+    stateRef.current = state
+  }, [state])
 
   const withInfraLock = useCallback(async <T>(work: () => Promise<T>): Promise<T> => {
     const previous = infraLockRef.current
@@ -666,6 +705,36 @@ export function useActions(repoRoot: string, config: PortConfig, refresh: () => 
     [appendSystemLog, state.runningByWorktree]
   )
 
+  const getRunningActionCount = useCallback(
+    (): number => Object.keys(state.runningByWorktree).length,
+    [state.runningByWorktree]
+  )
+
+  const shutdownJobs = useCallback(
+    async (options?: { timeoutMs?: number }): Promise<ShutdownJobsResult> => {
+      const runningJobIds = [...new Set(Object.values(stateRef.current.runningByWorktree))]
+
+      for (const jobId of runningJobIds) {
+        const controller = controllersRef.current.get(jobId)
+        if (!controller) continue
+        appendSystemLog(jobId, 'Cancellation requested (shutdown)')
+        controller.abort()
+      }
+
+      const drainResult = await waitForRunningActionsToDrain({
+        getState: () => stateRef.current,
+        timeoutMs: options?.timeoutMs ?? 5000,
+      })
+
+      return {
+        cancelledCount: runningJobIds.length,
+        timedOut: drainResult.timedOut,
+        remaining: drainResult.remaining,
+      }
+    },
+    [appendSystemLog]
+  )
+
   return {
     upWorktree,
     downWorktree,
@@ -675,5 +744,7 @@ export function useActions(repoRoot: string, config: PortConfig, refresh: () => 
     isWorktreeBusy,
     getOutputTail,
     cancelWorktreeAction,
+    getRunningActionCount,
+    shutdownJobs,
   }
 }

--- a/src/tui/hooks/useActions.ts
+++ b/src/tui/hooks/useActions.ts
@@ -1,4 +1,4 @@
-import { useCallback } from 'react'
+import { useCallback, useMemo, useReducer } from 'react'
 import type { PortConfig, HostService } from '../../types.ts'
 import { getComposeFile } from '../../lib/config.ts'
 import {
@@ -25,14 +25,223 @@ export interface ActionResult {
   message: string
 }
 
+export type ActionKind = 'up' | 'down' | 'archive' | 'kill-host-service'
+export type ActionJobStatus = 'queued' | 'running' | 'success' | 'error' | 'cancelled'
+
+interface ActionLogLine {
+  ts: number
+  stream: 'stdout' | 'stderr' | 'system'
+  line: string
+}
+
+export interface ActionJob {
+  id: string
+  kind: ActionKind
+  worktreeName: string
+  worktreePath: string
+  status: ActionJobStatus
+  summary: string
+  startedAt?: number
+  endedAt?: number
+  error?: string
+  logs: ActionLogLine[]
+}
+
+interface EnqueueSuccess {
+  accepted: true
+  jobId: string
+}
+
+interface EnqueueRejected {
+  accepted: false
+  reason: 'worktree_busy'
+  message: string
+}
+
+export type EnqueueResult = EnqueueSuccess | EnqueueRejected
+
+interface ActionState {
+  order: string[]
+  jobs: Record<string, ActionJob>
+  runningByWorktree: Record<string, string>
+}
+
+type ActionEvent =
+  | { type: 'enqueue'; job: ActionJob }
+  | { type: 'start'; jobId: string; startedAt: number }
+  | { type: 'log'; jobId: string; stream: ActionLogLine['stream']; line: string; ts: number }
+  | {
+      type: 'finish'
+      jobId: string
+      status: Extract<ActionJobStatus, 'success' | 'error' | 'cancelled'>
+      endedAt: number
+      error?: string
+    }
+
+const INITIAL_STATE: ActionState = {
+  order: [],
+  jobs: {},
+  runningByWorktree: {},
+}
+
+function reduceActionState(state: ActionState, event: ActionEvent): ActionState {
+  switch (event.type) {
+    case 'enqueue': {
+      return {
+        ...state,
+        order: [event.job.id, ...state.order],
+        jobs: {
+          ...state.jobs,
+          [event.job.id]: event.job,
+        },
+        runningByWorktree: {
+          ...state.runningByWorktree,
+          [event.job.worktreeName]: event.job.id,
+        },
+      }
+    }
+
+    case 'start': {
+      const existing = state.jobs[event.jobId]
+      if (!existing) return state
+      return {
+        ...state,
+        jobs: {
+          ...state.jobs,
+          [event.jobId]: {
+            ...existing,
+            status: 'running',
+            startedAt: event.startedAt,
+          },
+        },
+      }
+    }
+
+    case 'log': {
+      const existing = state.jobs[event.jobId]
+      if (!existing) return state
+      return {
+        ...state,
+        jobs: {
+          ...state.jobs,
+          [event.jobId]: {
+            ...existing,
+            logs: [...existing.logs, { ts: event.ts, stream: event.stream, line: event.line }],
+          },
+        },
+      }
+    }
+
+    case 'finish': {
+      const existing = state.jobs[event.jobId]
+      if (!existing) return state
+      const nextRunningByWorktree = { ...state.runningByWorktree }
+      delete nextRunningByWorktree[existing.worktreeName]
+
+      return {
+        ...state,
+        runningByWorktree: nextRunningByWorktree,
+        jobs: {
+          ...state.jobs,
+          [event.jobId]: {
+            ...existing,
+            status: event.status,
+            endedAt: event.endedAt,
+            error: event.error,
+          },
+        },
+      }
+    }
+  }
+}
+
+function createJobId(kind: ActionKind, worktreeName: string): string {
+  return `${kind}-${worktreeName}-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`
+}
+
 export function useActions(repoRoot: string, config: PortConfig, refresh: () => void) {
   const composeFile = getComposeFile(config)
+  const [state, dispatch] = useReducer(reduceActionState, INITIAL_STATE)
+
+  const appendSystemLog = useCallback((jobId: string, line: string) => {
+    dispatch({ type: 'log', jobId, stream: 'system', line, ts: Date.now() })
+  }, [])
+
+  const runJob = useCallback(
+    async (job: ActionJob, executor: (jobId: string) => Promise<ActionResult>): Promise<void> => {
+      dispatch({ type: 'start', jobId: job.id, startedAt: Date.now() })
+      appendSystemLog(job.id, `Starting ${job.kind} on ${job.worktreeName}`)
+
+      try {
+        const result = await executor(job.id)
+        if (result.success) {
+          appendSystemLog(job.id, result.message)
+          dispatch({ type: 'finish', jobId: job.id, status: 'success', endedAt: Date.now() })
+        } else {
+          appendSystemLog(job.id, result.message)
+          dispatch({
+            type: 'finish',
+            jobId: job.id,
+            status: 'error',
+            endedAt: Date.now(),
+            error: result.message,
+          })
+        }
+      } catch (err) {
+        const message = err instanceof Error ? err.message : String(err)
+        appendSystemLog(job.id, message)
+        dispatch({
+          type: 'finish',
+          jobId: job.id,
+          status: 'error',
+          endedAt: Date.now(),
+          error: message,
+        })
+      } finally {
+        refresh()
+      }
+    },
+    [appendSystemLog, refresh]
+  )
+
+  const enqueue = useCallback(
+    (
+      kind: ActionKind,
+      worktreePath: string,
+      worktreeName: string,
+      summary: string,
+      executor: (jobId: string) => Promise<ActionResult>
+    ): EnqueueResult => {
+      if (state.runningByWorktree[worktreeName]) {
+        return {
+          accepted: false,
+          reason: 'worktree_busy',
+          message: `Action already running for ${worktreeName}`,
+        }
+      }
+
+      const jobId = createJobId(kind, worktreeName)
+      const job: ActionJob = {
+        id: jobId,
+        kind,
+        worktreePath,
+        worktreeName,
+        status: 'queued',
+        summary,
+        logs: [],
+      }
+      dispatch({ type: 'enqueue', job })
+      void runJob(job, executor)
+      return { accepted: true, jobId }
+    },
+    [runJob, state.runningByWorktree]
+  )
 
   /**
    * Bring services up for a worktree.
    * Mirrors the logic in commands/up.ts but uses capture mode for stdio.
    */
-  const upWorktree = useCallback(
+  const runUpWorktree = useCallback(
     async (worktreePath: string, worktreeName: string): Promise<ActionResult> => {
       try {
         // Parse compose file
@@ -93,7 +302,7 @@ export function useActions(repoRoot: string, config: PortConfig, refresh: () => 
    * Bring services down for a worktree.
    * Mirrors the logic in commands/down.ts but uses capture mode.
    */
-  const downWorktree = useCallback(
+  const runDownWorktree = useCallback(
     async (worktreePath: string, worktreeName: string): Promise<ActionResult> => {
       try {
         const projectName = getProjectName(repoRoot, worktreeName)
@@ -137,7 +346,7 @@ export function useActions(repoRoot: string, config: PortConfig, refresh: () => 
   /**
    * Archive a worktree (stop services, remove worktree, archive branch).
    */
-  const archiveWorktree = useCallback(
+  const runArchiveWorktree = useCallback(
     async (worktreePath: string, worktreeName: string): Promise<ActionResult> => {
       try {
         // Stop services first
@@ -181,7 +390,7 @@ export function useActions(repoRoot: string, config: PortConfig, refresh: () => 
   /**
    * Kill a specific host service.
    */
-  const killHostService = useCallback(
+  const runKillHostService = useCallback(
     async (service: HostService): Promise<ActionResult> => {
       try {
         await stopHostService(service)
@@ -194,5 +403,76 @@ export function useActions(repoRoot: string, config: PortConfig, refresh: () => 
     [refresh]
   )
 
-  return { upWorktree, downWorktree, archiveWorktree, killHostService }
+  const upWorktree = useCallback(
+    (worktreePath: string, worktreeName: string): EnqueueResult => {
+      return enqueue('up', worktreePath, worktreeName, `Starting services in ${worktreeName}`, () =>
+        runUpWorktree(worktreePath, worktreeName)
+      )
+    },
+    [enqueue, runUpWorktree]
+  )
+
+  const downWorktree = useCallback(
+    (worktreePath: string, worktreeName: string): EnqueueResult => {
+      return enqueue(
+        'down',
+        worktreePath,
+        worktreeName,
+        `Stopping services in ${worktreeName}`,
+        () => runDownWorktree(worktreePath, worktreeName)
+      )
+    },
+    [enqueue, runDownWorktree]
+  )
+
+  const archiveWorktree = useCallback(
+    (worktreePath: string, worktreeName: string): EnqueueResult => {
+      return enqueue('archive', worktreePath, worktreeName, `Archiving ${worktreeName}`, () =>
+        runArchiveWorktree(worktreePath, worktreeName)
+      )
+    },
+    [enqueue, runArchiveWorktree]
+  )
+
+  const killHostService = useCallback(
+    (service: HostService): EnqueueResult => {
+      return enqueue(
+        'kill-host-service',
+        '',
+        service.branch,
+        `Stopping host service on ${service.branch}:${service.logicalPort}`,
+        () => runKillHostService(service)
+      )
+    },
+    [enqueue, runKillHostService]
+  )
+
+  const jobs = useMemo(() => state.order.map(jobId => state.jobs[jobId]!).filter(Boolean), [state])
+
+  const latestJobByWorktree = useMemo(() => {
+    const entries = new Map<string, ActionJob>()
+    for (const jobId of state.order) {
+      const job = state.jobs[jobId]
+      if (!job) continue
+      if (!entries.has(job.worktreeName)) {
+        entries.set(job.worktreeName, job)
+      }
+    }
+    return entries
+  }, [state])
+
+  const isWorktreeBusy = useCallback(
+    (worktreeName: string): boolean => Boolean(state.runningByWorktree[worktreeName]),
+    [state.runningByWorktree]
+  )
+
+  return {
+    upWorktree,
+    downWorktree,
+    archiveWorktree,
+    killHostService,
+    jobs,
+    latestJobByWorktree,
+    isWorktreeBusy,
+  }
 }

--- a/src/tui/hooks/useActions.ts
+++ b/src/tui/hooks/useActions.ts
@@ -75,6 +75,7 @@ export interface ActionState {
   jobs: Record<string, ActionJob>
   runningByWorktree: Record<string, string>
   outputTailByWorktree: Record<string, OutputTailLine[]>
+  outputVisibleByWorktree: Record<string, boolean>
 }
 
 export type ActionEvent =
@@ -89,12 +90,15 @@ export type ActionEvent =
       error?: string
     }
   | { type: 'trim'; maxJobs: number; maxLinesPerJob: number }
+  | { type: 'toggle-output-visible'; worktreeName: string }
+  | { type: 'set-output-visible'; worktreeName: string; visible: boolean }
 
 export const INITIAL_ACTION_STATE: ActionState = {
   order: [],
   jobs: {},
   runningByWorktree: {},
   outputTailByWorktree: {},
+  outputVisibleByWorktree: {},
 }
 
 export function reduceActionState(state: ActionState, event: ActionEvent): ActionState {
@@ -114,6 +118,10 @@ export function reduceActionState(state: ActionState, event: ActionEvent): Actio
         outputTailByWorktree: {
           ...state.outputTailByWorktree,
           [event.job.worktreeName]: [],
+        },
+        outputVisibleByWorktree: {
+          ...state.outputVisibleByWorktree,
+          [event.job.worktreeName]: true,
         },
       }
     }
@@ -225,6 +233,27 @@ export function reduceActionState(state: ActionState, event: ActionEvent): Actio
         order: keptOrder,
         jobs: nextJobs,
         runningByWorktree: nextRunningByWorktree,
+      }
+    }
+
+    case 'toggle-output-visible': {
+      const current = state.outputVisibleByWorktree[event.worktreeName] ?? true
+      return {
+        ...state,
+        outputVisibleByWorktree: {
+          ...state.outputVisibleByWorktree,
+          [event.worktreeName]: !current,
+        },
+      }
+    }
+
+    case 'set-output-visible': {
+      return {
+        ...state,
+        outputVisibleByWorktree: {
+          ...state.outputVisibleByWorktree,
+          [event.worktreeName]: event.visible,
+        },
       }
     }
 
@@ -686,6 +715,19 @@ export function useActions(repoRoot: string, config: PortConfig, refresh: () => 
     [state.outputTailByWorktree]
   )
 
+  const isOutputVisible = useCallback(
+    (worktreeName: string): boolean => state.outputVisibleByWorktree[worktreeName] ?? true,
+    [state.outputVisibleByWorktree]
+  )
+
+  const toggleOutputVisible = useCallback((worktreeName: string): void => {
+    dispatch({ type: 'toggle-output-visible', worktreeName })
+  }, [])
+
+  const showOutputForWorktree = useCallback((worktreeName: string): void => {
+    dispatch({ type: 'set-output-visible', worktreeName, visible: true })
+  }, [])
+
   const cancelWorktreeAction = useCallback(
     (worktreeName: string): boolean => {
       const runningJobId = state.runningByWorktree[worktreeName]
@@ -743,6 +785,9 @@ export function useActions(repoRoot: string, config: PortConfig, refresh: () => 
     latestJobByWorktree,
     isWorktreeBusy,
     getOutputTail,
+    isOutputVisible,
+    toggleOutputVisible,
+    showOutputForWorktree,
     cancelWorktreeAction,
     getRunningActionCount,
     shutdownJobs,

--- a/src/tui/hooks/useActions.ts
+++ b/src/tui/hooks/useActions.ts
@@ -64,6 +64,8 @@ interface ActionState {
   order: string[]
   jobs: Record<string, ActionJob>
   runningByWorktree: Record<string, string>
+  activeLogJobId: string | null
+  logOpen: boolean
 }
 
 type ActionEvent =
@@ -77,11 +79,16 @@ type ActionEvent =
       endedAt: number
       error?: string
     }
+  | { type: 'toggle-log' }
+  | { type: 'next-log-job' }
+  | { type: 'prev-log-job' }
 
 const INITIAL_STATE: ActionState = {
   order: [],
   jobs: {},
   runningByWorktree: {},
+  activeLogJobId: null,
+  logOpen: false,
 }
 
 function reduceActionState(state: ActionState, event: ActionEvent): ActionState {
@@ -90,6 +97,7 @@ function reduceActionState(state: ActionState, event: ActionEvent): ActionState 
       return {
         ...state,
         order: [event.job.id, ...state.order],
+        activeLogJobId: state.activeLogJobId ?? event.job.id,
         jobs: {
           ...state.jobs,
           [event.job.id]: event.job,
@@ -150,6 +158,38 @@ function reduceActionState(state: ActionState, event: ActionEvent): ActionState 
             error: event.error,
           },
         },
+      }
+    }
+
+    case 'toggle-log': {
+      const nextLogOpen = !state.logOpen
+      return {
+        ...state,
+        logOpen: nextLogOpen,
+        activeLogJobId: state.activeLogJobId ?? state.order[0] ?? null,
+      }
+    }
+
+    case 'next-log-job': {
+      if (state.order.length === 0) return state
+      const currentIndex = state.activeLogJobId ? state.order.indexOf(state.activeLogJobId) : -1
+      const nextIndex = currentIndex < 0 ? 0 : (currentIndex + 1) % state.order.length
+      return {
+        ...state,
+        activeLogJobId: state.order[nextIndex] ?? null,
+      }
+    }
+
+    case 'prev-log-job': {
+      if (state.order.length === 0) return state
+      const currentIndex = state.activeLogJobId ? state.order.indexOf(state.activeLogJobId) : -1
+      const prevIndex =
+        currentIndex < 0
+          ? state.order.length - 1
+          : (currentIndex - 1 + state.order.length) % state.order.length
+      return {
+        ...state,
+        activeLogJobId: state.order[prevIndex] ?? null,
       }
     }
   }
@@ -466,6 +506,23 @@ export function useActions(repoRoot: string, config: PortConfig, refresh: () => 
     [state.runningByWorktree]
   )
 
+  const activeLogJob = useMemo(
+    () => (state.activeLogJobId ? (state.jobs[state.activeLogJobId] ?? null) : null),
+    [state.activeLogJobId, state.jobs]
+  )
+
+  const toggleLog = useCallback(() => {
+    dispatch({ type: 'toggle-log' })
+  }, [])
+
+  const selectNextLogJob = useCallback(() => {
+    dispatch({ type: 'next-log-job' })
+  }, [])
+
+  const selectPrevLogJob = useCallback(() => {
+    dispatch({ type: 'prev-log-job' })
+  }, [])
+
   return {
     upWorktree,
     downWorktree,
@@ -474,5 +531,10 @@ export function useActions(repoRoot: string, config: PortConfig, refresh: () => 
     jobs,
     latestJobByWorktree,
     isWorktreeBusy,
+    logOpen: state.logOpen,
+    activeLogJob,
+    toggleLog,
+    selectNextLogJob,
+    selectPrevLogJob,
   }
 }

--- a/src/tui/hooks/useActions.ts
+++ b/src/tui/hooks/useActions.ts
@@ -59,7 +59,7 @@ interface EnqueueRejected {
 
 export type EnqueueResult = EnqueueSuccess | EnqueueRejected
 
-interface ActionState {
+export interface ActionState {
   order: string[]
   jobs: Record<string, ActionJob>
   runningByWorktree: Record<string, string>
@@ -67,7 +67,7 @@ interface ActionState {
   logOpen: boolean
 }
 
-type ActionEvent =
+export type ActionEvent =
   | { type: 'enqueue'; job: ActionJob }
   | { type: 'start'; jobId: string; startedAt: number }
   | { type: 'log'; jobId: string; stream: ActionLogLine['stream']; line: string; ts: number }
@@ -81,8 +81,9 @@ type ActionEvent =
   | { type: 'toggle-log' }
   | { type: 'next-log-job' }
   | { type: 'prev-log-job' }
+  | { type: 'trim'; maxJobs: number; maxLinesPerJob: number }
 
-const INITIAL_STATE: ActionState = {
+export const INITIAL_ACTION_STATE: ActionState = {
   order: [],
   jobs: {},
   runningByWorktree: {},
@@ -90,7 +91,7 @@ const INITIAL_STATE: ActionState = {
   logOpen: false,
 }
 
-function reduceActionState(state: ActionState, event: ActionEvent): ActionState {
+export function reduceActionState(state: ActionState, event: ActionEvent): ActionState {
   switch (event.type) {
     case 'enqueue': {
       return {
@@ -191,6 +192,94 @@ function reduceActionState(state: ActionState, event: ActionEvent): ActionState 
         activeLogJobId: state.order[prevIndex] ?? null,
       }
     }
+
+    case 'trim': {
+      if (state.order.length <= event.maxJobs) {
+        let changed = false
+        const nextJobs: Record<string, ActionJob> = {}
+        for (const jobId of state.order) {
+          const job = state.jobs[jobId]
+          if (!job) continue
+          const trimmedLogs =
+            job.logs.length > event.maxLinesPerJob
+              ? job.logs.slice(-event.maxLinesPerJob)
+              : job.logs
+          if (trimmedLogs.length !== job.logs.length) {
+            changed = true
+            nextJobs[jobId] = { ...job, logs: trimmedLogs }
+          } else {
+            nextJobs[jobId] = job
+          }
+        }
+        if (!changed) return state
+        return { ...state, jobs: nextJobs }
+      }
+
+      const keptOrder = state.order.slice(0, event.maxJobs)
+      const nextJobs: Record<string, ActionJob> = {}
+      for (const jobId of keptOrder) {
+        const job = state.jobs[jobId]
+        if (!job) continue
+        nextJobs[jobId] = {
+          ...job,
+          logs: job.logs.slice(-event.maxLinesPerJob),
+        }
+      }
+
+      const nextRunningByWorktree: Record<string, string> = {}
+      for (const [worktree, jobId] of Object.entries(state.runningByWorktree)) {
+        if (nextJobs[jobId]) {
+          nextRunningByWorktree[worktree] = jobId
+        }
+      }
+
+      return {
+        ...state,
+        order: keptOrder,
+        jobs: nextJobs,
+        runningByWorktree: nextRunningByWorktree,
+        activeLogJobId:
+          state.activeLogJobId && nextJobs[state.activeLogJobId]
+            ? state.activeLogJobId
+            : (keptOrder[0] ?? null),
+      }
+    }
+  }
+}
+
+interface EnqueueDecisionAccepted {
+  accepted: true
+  job: ActionJob
+}
+
+type EnqueueDecision = EnqueueDecisionAccepted | EnqueueRejected
+
+export function createEnqueueDecision(params: {
+  state: ActionState
+  kind: ActionKind
+  worktreePath: string
+  worktreeName: string
+  summary: string
+}): EnqueueDecision {
+  if (params.state.runningByWorktree[params.worktreeName]) {
+    return {
+      accepted: false,
+      reason: 'worktree_busy',
+      message: `Action already running for ${params.worktreeName}`,
+    }
+  }
+
+  return {
+    accepted: true,
+    job: {
+      id: createJobId(params.kind, params.worktreeName),
+      kind: params.kind,
+      worktreePath: params.worktreePath,
+      worktreeName: params.worktreeName,
+      status: 'queued',
+      summary: params.summary,
+      logs: [],
+    },
   }
 }
 
@@ -200,7 +289,7 @@ function createJobId(kind: ActionKind, worktreeName: string): string {
 
 export function useActions(repoRoot: string, config: PortConfig, refresh: () => void) {
   const composeFile = getComposeFile(config)
-  const [state, dispatch] = useReducer(reduceActionState, INITIAL_STATE)
+  const [state, dispatch] = useReducer(reduceActionState, INITIAL_ACTION_STATE)
   const controllersRef = useRef(new Map<string, AbortController>())
   const infraLockRef = useRef<Promise<void>>(Promise.resolve())
 
@@ -283,27 +372,23 @@ export function useActions(repoRoot: string, config: PortConfig, refresh: () => 
       summary: string,
       executor: (jobId: string, signal: AbortSignal) => Promise<ActionResult>
     ): EnqueueResult => {
-      if (state.runningByWorktree[worktreeName]) {
-        return {
-          accepted: false,
-          reason: 'worktree_busy',
-          message: `Action already running for ${worktreeName}`,
-        }
-      }
-
-      const jobId = createJobId(kind, worktreeName)
-      const job: ActionJob = {
-        id: jobId,
+      const decision = createEnqueueDecision({
+        state,
         kind,
         worktreePath,
         worktreeName,
-        status: 'queued',
         summary,
-        logs: [],
+      })
+
+      if (!decision.accepted) {
+        return decision
       }
+
+      const job = decision.job
       dispatch({ type: 'enqueue', job })
+      dispatch({ type: 'trim', maxJobs: 20, maxLinesPerJob: 300 })
       void runJob(job, executor)
-      return { accepted: true, jobId }
+      return { accepted: true, jobId: job.id }
     },
     [runJob, state.runningByWorktree]
   )

--- a/src/tui/hooks/useActions.ts
+++ b/src/tui/hooks/useActions.ts
@@ -33,6 +33,11 @@ interface ActionLogLine {
   line: string
 }
 
+export interface OutputTailLine {
+  stream: 'stdout' | 'stderr'
+  line: string
+}
+
 export interface ActionJob {
   id: string
   kind: ActionKind
@@ -63,8 +68,7 @@ export interface ActionState {
   order: string[]
   jobs: Record<string, ActionJob>
   runningByWorktree: Record<string, string>
-  activeLogJobId: string | null
-  logOpen: boolean
+  outputTailByWorktree: Record<string, OutputTailLine[]>
 }
 
 export type ActionEvent =
@@ -78,17 +82,13 @@ export type ActionEvent =
       endedAt: number
       error?: string
     }
-  | { type: 'toggle-log' }
-  | { type: 'next-log-job' }
-  | { type: 'prev-log-job' }
   | { type: 'trim'; maxJobs: number; maxLinesPerJob: number }
 
 export const INITIAL_ACTION_STATE: ActionState = {
   order: [],
   jobs: {},
   runningByWorktree: {},
-  activeLogJobId: null,
-  logOpen: false,
+  outputTailByWorktree: {},
 }
 
 export function reduceActionState(state: ActionState, event: ActionEvent): ActionState {
@@ -97,7 +97,6 @@ export function reduceActionState(state: ActionState, event: ActionEvent): Actio
       return {
         ...state,
         order: [event.job.id, ...state.order],
-        activeLogJobId: state.activeLogJobId ?? event.job.id,
         jobs: {
           ...state.jobs,
           [event.job.id]: event.job,
@@ -105,6 +104,10 @@ export function reduceActionState(state: ActionState, event: ActionEvent): Actio
         runningByWorktree: {
           ...state.runningByWorktree,
           [event.job.worktreeName]: event.job.id,
+        },
+        outputTailByWorktree: {
+          ...state.outputTailByWorktree,
+          [event.job.worktreeName]: [],
         },
       }
     }
@@ -137,6 +140,16 @@ export function reduceActionState(state: ActionState, event: ActionEvent): Actio
             logs: [...existing.logs, { ts: event.ts, stream: event.stream, line: event.line }],
           },
         },
+        outputTailByWorktree:
+          event.stream === 'system'
+            ? state.outputTailByWorktree
+            : {
+                ...state.outputTailByWorktree,
+                [existing.worktreeName]: [
+                  ...(state.outputTailByWorktree[existing.worktreeName] ?? []),
+                  { stream: event.stream, line: event.line },
+                ].slice(-2),
+              },
       }
     }
 
@@ -158,38 +171,6 @@ export function reduceActionState(state: ActionState, event: ActionEvent): Actio
             error: event.error,
           },
         },
-      }
-    }
-
-    case 'toggle-log': {
-      const nextLogOpen = !state.logOpen
-      return {
-        ...state,
-        logOpen: nextLogOpen,
-        activeLogJobId: state.activeLogJobId ?? state.order[0] ?? null,
-      }
-    }
-
-    case 'next-log-job': {
-      if (state.order.length === 0) return state
-      const currentIndex = state.activeLogJobId ? state.order.indexOf(state.activeLogJobId) : -1
-      const nextIndex = currentIndex < 0 ? 0 : (currentIndex + 1) % state.order.length
-      return {
-        ...state,
-        activeLogJobId: state.order[nextIndex] ?? null,
-      }
-    }
-
-    case 'prev-log-job': {
-      if (state.order.length === 0) return state
-      const currentIndex = state.activeLogJobId ? state.order.indexOf(state.activeLogJobId) : -1
-      const prevIndex =
-        currentIndex < 0
-          ? state.order.length - 1
-          : (currentIndex - 1 + state.order.length) % state.order.length
-      return {
-        ...state,
-        activeLogJobId: state.order[prevIndex] ?? null,
       }
     }
 
@@ -238,12 +219,11 @@ export function reduceActionState(state: ActionState, event: ActionEvent): Actio
         order: keptOrder,
         jobs: nextJobs,
         runningByWorktree: nextRunningByWorktree,
-        activeLogJobId:
-          state.activeLogJobId && nextJobs[state.activeLogJobId]
-            ? state.activeLogJobId
-            : (keptOrder[0] ?? null),
       }
     }
+
+    default:
+      return state
   }
 }
 
@@ -645,8 +625,6 @@ export function useActions(repoRoot: string, config: PortConfig, refresh: () => 
     [enqueue, runKillHostService]
   )
 
-  const jobs = useMemo(() => state.order.map(jobId => state.jobs[jobId]!).filter(Boolean), [state])
-
   const latestJobByWorktree = useMemo(() => {
     const entries = new Map<string, ActionJob>()
     for (const jobId of state.order) {
@@ -664,56 +642,38 @@ export function useActions(repoRoot: string, config: PortConfig, refresh: () => 
     [state.runningByWorktree]
   )
 
-  const activeLogJob = useMemo(
-    () => (state.activeLogJobId ? (state.jobs[state.activeLogJobId] ?? null) : null),
-    [state.activeLogJobId, state.jobs]
+  const getOutputTail = useCallback(
+    (worktreeName: string): OutputTailLine[] => state.outputTailByWorktree[worktreeName] ?? [],
+    [state.outputTailByWorktree]
   )
 
-  const toggleLog = useCallback(() => {
-    dispatch({ type: 'toggle-log' })
-  }, [])
+  const cancelWorktreeAction = useCallback(
+    (worktreeName: string): boolean => {
+      const runningJobId = state.runningByWorktree[worktreeName]
+      if (!runningJobId) {
+        return false
+      }
 
-  const selectNextLogJob = useCallback(() => {
-    dispatch({ type: 'next-log-job' })
-  }, [])
+      const controller = controllersRef.current.get(runningJobId)
+      if (!controller) {
+        return false
+      }
 
-  const selectPrevLogJob = useCallback(() => {
-    dispatch({ type: 'prev-log-job' })
-  }, [])
-
-  const cancelActiveLogJob = useCallback((): boolean => {
-    if (!state.activeLogJobId) {
-      return false
-    }
-
-    const job = state.jobs[state.activeLogJobId]
-    if (!job || job.status !== 'running') {
-      return false
-    }
-
-    const controller = controllersRef.current.get(job.id)
-    if (!controller) {
-      return false
-    }
-
-    appendSystemLog(job.id, 'Cancellation requested')
-    controller.abort()
-    return true
-  }, [appendSystemLog, state.activeLogJobId, state.jobs])
+      appendSystemLog(runningJobId, 'Cancellation requested')
+      controller.abort()
+      return true
+    },
+    [appendSystemLog, state.runningByWorktree]
+  )
 
   return {
     upWorktree,
     downWorktree,
     archiveWorktree,
     killHostService,
-    jobs,
     latestJobByWorktree,
     isWorktreeBusy,
-    logOpen: state.logOpen,
-    activeLogJob,
-    toggleLog,
-    selectNextLogJob,
-    selectPrevLogJob,
-    cancelActiveLogJob,
+    getOutputTail,
+    cancelWorktreeAction,
   }
 }

--- a/src/tui/hooks/useActions.ts
+++ b/src/tui/hooks/useActions.ts
@@ -1,4 +1,4 @@
-import { useCallback, useMemo, useReducer } from 'react'
+import { useCallback, useMemo, useReducer, useRef } from 'react'
 import type { PortConfig, HostService } from '../../types.ts'
 import { getComposeFile } from '../../lib/config.ts'
 import {
@@ -11,7 +11,6 @@ import {
   parseComposeFile,
   getAllPorts,
   getProjectName,
-  type ComposeCapturedResult,
 } from '../../lib/compose.ts'
 import { registerProject, unregisterProject } from '../../lib/registry.ts'
 import { ensureTraefikPorts, traefikFilesExist, initTraefikFiles } from '../../lib/traefik.ts'
@@ -202,21 +201,47 @@ function createJobId(kind: ActionKind, worktreeName: string): string {
 export function useActions(repoRoot: string, config: PortConfig, refresh: () => void) {
   const composeFile = getComposeFile(config)
   const [state, dispatch] = useReducer(reduceActionState, INITIAL_STATE)
+  const controllersRef = useRef(new Map<string, AbortController>())
+  const infraLockRef = useRef<Promise<void>>(Promise.resolve())
+
+  const withInfraLock = useCallback(async <T>(work: () => Promise<T>): Promise<T> => {
+    const previous = infraLockRef.current
+    let releaseLock!: () => void
+    const current = new Promise<void>(resolve => {
+      releaseLock = resolve
+    })
+    infraLockRef.current = current
+
+    await previous
+    try {
+      return await work()
+    } finally {
+      releaseLock()
+    }
+  }, [])
 
   const appendSystemLog = useCallback((jobId: string, line: string) => {
     dispatch({ type: 'log', jobId, stream: 'system', line, ts: Date.now() })
   }, [])
 
   const runJob = useCallback(
-    async (job: ActionJob, executor: (jobId: string) => Promise<ActionResult>): Promise<void> => {
+    async (
+      job: ActionJob,
+      executor: (jobId: string, signal: AbortSignal) => Promise<ActionResult>
+    ): Promise<void> => {
+      const controller = new AbortController()
+      controllersRef.current.set(job.id, controller)
       dispatch({ type: 'start', jobId: job.id, startedAt: Date.now() })
       appendSystemLog(job.id, `Starting ${job.kind} on ${job.worktreeName}`)
 
       try {
-        const result = await executor(job.id)
+        const result = await executor(job.id, controller.signal)
         if (result.success) {
           appendSystemLog(job.id, result.message)
           dispatch({ type: 'finish', jobId: job.id, status: 'success', endedAt: Date.now() })
+        } else if (controller.signal.aborted) {
+          appendSystemLog(job.id, 'Action cancelled')
+          dispatch({ type: 'finish', jobId: job.id, status: 'cancelled', endedAt: Date.now() })
         } else {
           appendSystemLog(job.id, result.message)
           dispatch({
@@ -229,15 +254,21 @@ export function useActions(repoRoot: string, config: PortConfig, refresh: () => 
         }
       } catch (err) {
         const message = err instanceof Error ? err.message : String(err)
-        appendSystemLog(job.id, message)
-        dispatch({
-          type: 'finish',
-          jobId: job.id,
-          status: 'error',
-          endedAt: Date.now(),
-          error: message,
-        })
+        if (controller.signal.aborted) {
+          appendSystemLog(job.id, 'Action cancelled')
+          dispatch({ type: 'finish', jobId: job.id, status: 'cancelled', endedAt: Date.now() })
+        } else {
+          appendSystemLog(job.id, message)
+          dispatch({
+            type: 'finish',
+            jobId: job.id,
+            status: 'error',
+            endedAt: Date.now(),
+            error: message,
+          })
+        }
       } finally {
+        controllersRef.current.delete(job.id)
         refresh()
       }
     },
@@ -250,7 +281,7 @@ export function useActions(repoRoot: string, config: PortConfig, refresh: () => 
       worktreePath: string,
       worktreeName: string,
       summary: string,
-      executor: (jobId: string) => Promise<ActionResult>
+      executor: (jobId: string, signal: AbortSignal) => Promise<ActionResult>
     ): EnqueueResult => {
       if (state.runningByWorktree[worktreeName]) {
         return {
@@ -279,28 +310,35 @@ export function useActions(repoRoot: string, config: PortConfig, refresh: () => 
 
   /**
    * Bring services up for a worktree.
-   * Mirrors the logic in commands/up.ts but uses capture mode for stdio.
+   * Mirrors the logic in commands/up.ts but streams output into the action log.
    */
   const runUpWorktree = useCallback(
-    async (worktreePath: string, worktreeName: string): Promise<ActionResult> => {
+    async (
+      worktreePath: string,
+      worktreeName: string,
+      jobId: string,
+      signal: AbortSignal
+    ): Promise<ActionResult> => {
       try {
         // Parse compose file
         const parsedCompose = await parseComposeFile(worktreePath, composeFile)
         const ports = getAllPorts(parsedCompose)
 
-        // Ensure Traefik files
-        if (!traefikFilesExist()) {
-          await initTraefikFiles(ports)
-        }
-        await ensureTraefikPorts(ports)
+        await withInfraLock(async () => {
+          // Ensure Traefik files
+          if (!traefikFilesExist()) {
+            await initTraefikFiles(ports)
+          }
+          await ensureTraefikPorts(ports)
 
-        // Ensure Traefik is running
-        const traefikRunning = await isTraefikRunning()
-        if (!traefikRunning) {
-          await startTraefik()
-        } else if (!(await traefikHasRequiredPorts(ports))) {
-          await restartTraefik()
-        }
+          // Ensure Traefik is running
+          const traefikRunning = await isTraefikRunning()
+          if (!traefikRunning) {
+            await startTraefik()
+          } else if (!(await traefikHasRequiredPorts(ports))) {
+            await restartTraefik()
+          }
+        })
 
         const projectName = getProjectName(repoRoot, worktreeName)
 
@@ -313,48 +351,66 @@ export function useActions(repoRoot: string, config: PortConfig, refresh: () => 
           projectName
         )
 
-        // Start services (capture mode - don't stomp TUI)
-        const result = (await runCompose(
+        // Start services and stream output into the action log.
+        const result = await runCompose(
           worktreePath,
           composeFile,
           projectName,
           ['up', '-d'],
           { repoRoot, branch: worktreeName, domain: config.domain },
-          { stdio: 'capture' }
-        )) as ComposeCapturedResult
+          {
+            stdio: 'stream',
+            signal,
+            onStdoutLine: line =>
+              dispatch({ type: 'log', jobId, stream: 'stdout', line, ts: Date.now() }),
+            onStderrLine: line =>
+              dispatch({ type: 'log', jobId, stream: 'stderr', line, ts: Date.now() }),
+          }
+        )
 
         if (result.exitCode !== 0) {
-          return { success: false, message: result.stderr || 'Failed to start services' }
+          return { success: false, message: 'Failed to start services' }
         }
 
         // Register project
         await registerProject(repoRoot, worktreeName, ports)
-        refresh()
         return { success: true, message: `Services started in ${worktreeName}` }
       } catch (err) {
         return { success: false, message: err instanceof Error ? err.message : String(err) }
       }
     },
-    [repoRoot, config, composeFile, refresh]
+    [repoRoot, config, composeFile, refresh, withInfraLock]
   )
 
   /**
    * Bring services down for a worktree.
-   * Mirrors the logic in commands/down.ts but uses capture mode.
+   * Mirrors the logic in commands/down.ts but streams output into the action log.
    */
   const runDownWorktree = useCallback(
-    async (worktreePath: string, worktreeName: string): Promise<ActionResult> => {
+    async (
+      worktreePath: string,
+      worktreeName: string,
+      jobId: string,
+      signal: AbortSignal
+    ): Promise<ActionResult> => {
       try {
         const projectName = getProjectName(repoRoot, worktreeName)
 
-        const result = (await runCompose(
+        const result = await runCompose(
           worktreePath,
           composeFile,
           projectName,
           ['down'],
           { repoRoot, branch: worktreeName, domain: config.domain },
-          { stdio: 'capture' }
-        )) as ComposeCapturedResult
+          {
+            stdio: 'stream',
+            signal,
+            onStdoutLine: line =>
+              dispatch({ type: 'log', jobId, stream: 'stdout', line, ts: Date.now() }),
+            onStderrLine: line =>
+              dispatch({ type: 'log', jobId, stream: 'stderr', line, ts: Date.now() }),
+          }
+        )
 
         // Unregister project
         await unregisterProject(repoRoot, worktreeName)
@@ -369,10 +425,8 @@ export function useActions(repoRoot: string, config: PortConfig, refresh: () => 
           }
         }
 
-        refresh()
-
         if (result.exitCode !== 0) {
-          return { success: false, message: result.stderr || 'Failed to stop services' }
+          return { success: false, message: 'Failed to stop services' }
         }
 
         return { success: true, message: `Services stopped in ${worktreeName}` }
@@ -387,7 +441,12 @@ export function useActions(repoRoot: string, config: PortConfig, refresh: () => 
    * Archive a worktree (stop services, remove worktree, archive branch).
    */
   const runArchiveWorktree = useCallback(
-    async (worktreePath: string, worktreeName: string): Promise<ActionResult> => {
+    async (
+      worktreePath: string,
+      worktreeName: string,
+      jobId: string,
+      signal: AbortSignal
+    ): Promise<ActionResult> => {
       try {
         // Stop services first
         const projectName = getProjectName(repoRoot, worktreeName)
@@ -397,7 +456,14 @@ export function useActions(repoRoot: string, config: PortConfig, refresh: () => 
           projectName,
           ['down'],
           { repoRoot, branch: worktreeName, domain: config.domain },
-          { stdio: 'capture' }
+          {
+            stdio: 'stream',
+            signal,
+            onStdoutLine: line =>
+              dispatch({ type: 'log', jobId, stream: 'stdout', line, ts: Date.now() }),
+            onStderrLine: line =>
+              dispatch({ type: 'log', jobId, stream: 'stderr', line, ts: Date.now() }),
+          }
         )
 
         await unregisterProject(repoRoot, worktreeName)
@@ -418,7 +484,6 @@ export function useActions(repoRoot: string, config: PortConfig, refresh: () => 
         // Archive branch
         await archiveBranch(repoRoot, worktreeName)
 
-        refresh()
         return { success: true, message: `Worktree ${worktreeName} archived` }
       } catch (err) {
         return { success: false, message: err instanceof Error ? err.message : String(err) }
@@ -445,8 +510,12 @@ export function useActions(repoRoot: string, config: PortConfig, refresh: () => 
 
   const upWorktree = useCallback(
     (worktreePath: string, worktreeName: string): EnqueueResult => {
-      return enqueue('up', worktreePath, worktreeName, `Starting services in ${worktreeName}`, () =>
-        runUpWorktree(worktreePath, worktreeName)
+      return enqueue(
+        'up',
+        worktreePath,
+        worktreeName,
+        `Starting services in ${worktreeName}`,
+        (jobId, signal) => runUpWorktree(worktreePath, worktreeName, jobId, signal)
       )
     },
     [enqueue, runUpWorktree]
@@ -459,7 +528,7 @@ export function useActions(repoRoot: string, config: PortConfig, refresh: () => 
         worktreePath,
         worktreeName,
         `Stopping services in ${worktreeName}`,
-        () => runDownWorktree(worktreePath, worktreeName)
+        (jobId, signal) => runDownWorktree(worktreePath, worktreeName, jobId, signal)
       )
     },
     [enqueue, runDownWorktree]
@@ -467,8 +536,12 @@ export function useActions(repoRoot: string, config: PortConfig, refresh: () => 
 
   const archiveWorktree = useCallback(
     (worktreePath: string, worktreeName: string): EnqueueResult => {
-      return enqueue('archive', worktreePath, worktreeName, `Archiving ${worktreeName}`, () =>
-        runArchiveWorktree(worktreePath, worktreeName)
+      return enqueue(
+        'archive',
+        worktreePath,
+        worktreeName,
+        `Archiving ${worktreeName}`,
+        (jobId, signal) => runArchiveWorktree(worktreePath, worktreeName, jobId, signal)
       )
     },
     [enqueue, runArchiveWorktree]
@@ -523,6 +596,26 @@ export function useActions(repoRoot: string, config: PortConfig, refresh: () => 
     dispatch({ type: 'prev-log-job' })
   }, [])
 
+  const cancelActiveLogJob = useCallback((): boolean => {
+    if (!state.activeLogJobId) {
+      return false
+    }
+
+    const job = state.jobs[state.activeLogJobId]
+    if (!job || job.status !== 'running') {
+      return false
+    }
+
+    const controller = controllersRef.current.get(job.id)
+    if (!controller) {
+      return false
+    }
+
+    appendSystemLog(job.id, 'Cancellation requested')
+    controller.abort()
+    return true
+  }, [appendSystemLog, state.activeLogJobId, state.jobs])
+
   return {
     upWorktree,
     downWorktree,
@@ -536,5 +629,6 @@ export function useActions(repoRoot: string, config: PortConfig, refresh: () => 
     toggleLog,
     selectNextLogJob,
     selectPrevLogJob,
+    cancelActiveLogJob,
   }
 }

--- a/src/tui/hooks/useActions.ts
+++ b/src/tui/hooks/useActions.ts
@@ -176,6 +176,10 @@ export function reduceActionState(state: ActionState, event: ActionEvent): Actio
       return {
         ...state,
         runningByWorktree: nextRunningByWorktree,
+        outputVisibleByWorktree: {
+          ...state.outputVisibleByWorktree,
+          [existing.worktreeName]: false,
+        },
         jobs: {
           ...state.jobs,
           [event.jobId]: {

--- a/src/tui/views/Dashboard.tsx
+++ b/src/tui/views/Dashboard.tsx
@@ -517,124 +517,129 @@ export function Dashboard({
         <b>Worktrees</b>
       </text>
 
-      {/* Worktree rows */}
-      <scrollbox
-        ref={scrollRef}
-        flexGrow={0}
-        flexShrink={1}
-        scrollY
-        scrollX={false}
-        contentOptions={{ flexDirection: 'column', width: '100%' }}
-      >
-        {worktrees.length === 0 && !loading && <text fg="#888888">No worktrees found</text>}
+      <box flexDirection="column" flexGrow={1} flexShrink={1} minHeight={0}>
+        {/* Worktree rows */}
+        <scrollbox
+          ref={scrollRef}
+          flexGrow={0}
+          flexShrink={1}
+          scrollY
+          scrollX={false}
+          contentOptions={{ flexDirection: 'column', width: '100%' }}
+        >
+          {worktrees.length === 0 && !loading && <text fg="#888888">No worktrees found</text>}
 
-        {worktrees.map((worktree, index) => {
-          const isSelected = index === selectedIndex
-          const isRoot = index === 0
-          const isActive = worktree.name === activeWorktreeName
-          const sortedServices = [...worktree.services].sort(
-            (a, b) => Number(b.running) - Number(a.running)
-          )
-          const servicesText = buildServicesText(sortedServices)
-          const totalCount = worktree.services.length
-          const nameStr = worktree.name + (isRoot ? ' (root)' : '')
-          const matchRanges = highlightQuery
-            ? findSubstringMatchRanges(nameStr, highlightQuery)
-            : []
-          const latestJob = actions.latestJobByWorktree.get(worktree.name)
-          const runningAction = actions.isWorktreeBusy(worktree.name)
+          {worktrees.map((worktree, index) => {
+            const isSelected = index === selectedIndex
+            const isRoot = index === 0
+            const isActive = worktree.name === activeWorktreeName
+            const sortedServices = [...worktree.services].sort(
+              (a, b) => Number(b.running) - Number(a.running)
+            )
+            const servicesText = buildServicesText(sortedServices)
+            const totalCount = worktree.services.length
+            const nameStr = worktree.name + (isRoot ? ' (root)' : '')
+            const matchRanges = highlightQuery
+              ? findSubstringMatchRanges(nameStr, highlightQuery)
+              : []
+            const latestJob = actions.latestJobByWorktree.get(worktree.name)
+            const runningAction = actions.isWorktreeBusy(worktree.name)
 
-          return (
-            <box key={worktree.name} flexDirection="row" height={1} overflow="hidden">
-              <text wrapMode="none" flexShrink={0}>
-                {isSelected ? '> ' : '  '}
-              </text>
-              {isActive && (
-                <text wrapMode="none" flexShrink={0} fg="#FFFF00">
-                  ★{' '}
-                </text>
-              )}
-              <text flexShrink={1} wrapMode="none">
-                {matchRanges.length > 0 ? buildHighlightedSegments(nameStr, matchRanges) : nameStr}
-              </text>
-              {runningAction && latestJob && (
-                <text wrapMode="none" flexShrink={0} fg="#FFFF00">
-                  {'  ' + latestJob.kind + '...'}
-                </text>
-              )}
-              {!runningAction && latestJob?.status === 'error' && (
-                <text wrapMode="none" flexShrink={0} fg="#FF4444">
-                  {'  ' + latestJob.kind + ' failed'}
-                </text>
-              )}
-              {totalCount === 0 && loading && (
-                <text wrapMode="none" flexShrink={0} fg="#555555">
-                  {' ...'}
-                </text>
-              )}
-              {totalCount > 0 && (
+            return (
+              <box key={worktree.name} flexDirection="row" height={1} overflow="hidden">
                 <text wrapMode="none" flexShrink={0}>
-                  {'  '}
+                  {isSelected ? '> ' : '  '}
                 </text>
-              )}
-              {totalCount > 0 && (
-                <text fg="#888888" flexShrink={100} wrapMode="none">
-                  {servicesText}
+                {isActive && (
+                  <text wrapMode="none" flexShrink={0} fg="#FFFF00">
+                    ★{' '}
+                  </text>
+                )}
+                <text flexShrink={1} wrapMode="none">
+                  {matchRanges.length > 0
+                    ? buildHighlightedSegments(nameStr, matchRanges)
+                    : nameStr}
                 </text>
-              )}
-              {totalCount > 0 && (
-                <text wrapMode="none" flexShrink={0} fg="#555555">
-                  {'  ' + totalCount + ' total'}
-                </text>
-              )}
-            </box>
-          )
-        })}
-      </scrollbox>
+                {runningAction && latestJob && (
+                  <text wrapMode="none" flexShrink={0} fg="#FFFF00">
+                    {'  ' + latestJob.kind + '...'}
+                  </text>
+                )}
+                {!runningAction && latestJob?.status === 'error' && (
+                  <text wrapMode="none" flexShrink={0} fg="#FF4444">
+                    {'  ' + latestJob.kind + ' failed'}
+                  </text>
+                )}
+                {totalCount === 0 && loading && (
+                  <text wrapMode="none" flexShrink={0} fg="#555555">
+                    {' ...'}
+                  </text>
+                )}
+                {totalCount > 0 && (
+                  <text wrapMode="none" flexShrink={0}>
+                    {'  '}
+                  </text>
+                )}
+                {totalCount > 0 && (
+                  <text fg="#888888" flexShrink={100} wrapMode="none">
+                    {servicesText}
+                  </text>
+                )}
+                {totalCount > 0 && (
+                  <text wrapMode="none" flexShrink={0} fg="#555555">
+                    {'  ' + totalCount + ' total'}
+                  </text>
+                )}
+              </box>
+            )
+          })}
+        </scrollbox>
 
-      <box height={1} flexShrink={0} />
+        <box height={1} flexShrink={0} />
 
-      {/* Status message */}
-      {statusMessage && (
-        <text fg={statusMessage.type === 'success' ? '#00FF00' : '#FF4444'} flexShrink={0}>
-          {statusMessage.text}
-        </text>
-      )}
-
-      {showOutput && selectedWorktree && (
-        <box flexDirection="column" flexGrow={1} flexShrink={1} minHeight={3}>
-          <box height={1} flexShrink={0} />
-          <text fg="#888888" flexShrink={0}>
-            <b>
-              {formatOutputTitle(selectedWorktree.name, selectedLatestJob, selectedRunningAction)}
-            </b>{' '}
-            <span fg="#CCCCCC">[l]</span> toggle
+        {/* Status message */}
+        {statusMessage && (
+          <text fg={statusMessage.type === 'success' ? '#00FF00' : '#FF4444'} flexShrink={0}>
+            {statusMessage.text}
           </text>
-          <scrollbox
-            ref={node => {
-              outputScrollRef.current = node
-              if (node && selectedRunningAction) {
-                node.scrollTop = Number.MAX_SAFE_INTEGER
-              }
-            }}
-            flexGrow={1}
-            flexShrink={1}
-            scrollY
-            scrollX={false}
-            contentOptions={{ flexDirection: 'column', width: '100%' }}
-          >
-            {selectedOutputLines.map((entry, index) => (
-              <text
-                key={`${selectedWorktree.name}-output-${index}`}
-                fg={entry.stream === 'stderr' ? '#FF8888' : '#888888'}
-              >
-                {entry.line}
-              </text>
-            ))}
-            {selectedOutputLines.length === 0 && <text fg="#666666">No output yet...</text>}
-          </scrollbox>
-        </box>
-      )}
+        )}
+
+        {showOutput && selectedWorktree && (
+          <box flexDirection="column" flexGrow={1} flexShrink={1} minHeight={0}>
+            <box flexGrow={1} />
+            <text fg="#888888" flexShrink={0}>
+              <b>
+                {formatOutputTitle(selectedWorktree.name, selectedLatestJob, selectedRunningAction)}
+              </b>{' '}
+              <span fg="#CCCCCC">[l]</span> toggle
+            </text>
+            <scrollbox
+              ref={node => {
+                outputScrollRef.current = node
+                if (node && selectedRunningAction) {
+                  node.scrollTop = Number.MAX_SAFE_INTEGER
+                }
+              }}
+              flexGrow={1}
+              flexShrink={1}
+              minHeight={2}
+              scrollY
+              scrollX={false}
+              contentOptions={{ flexDirection: 'column', width: '100%' }}
+            >
+              {selectedOutputLines.map((entry, index) => (
+                <text
+                  key={`${selectedWorktree.name}-output-${index}`}
+                  fg={entry.stream === 'stderr' ? '#FF8888' : '#888888'}
+                >
+                  {entry.line}
+                </text>
+              ))}
+              {selectedOutputLines.length === 0 && <text fg="#666666">No output yet...</text>}
+            </scrollbox>
+          </box>
+        )}
+      </box>
 
       {/* Jump prompt */}
       <text

--- a/src/tui/views/Dashboard.tsx
+++ b/src/tui/views/Dashboard.tsx
@@ -21,6 +21,7 @@ interface Actions {
   toggleLog: () => void
   selectNextLogJob: () => void
   selectPrevLogJob: () => void
+  cancelActiveLogJob: () => boolean
 }
 
 interface DashboardProps {
@@ -325,6 +326,13 @@ export function Dashboard({
       return
     }
 
+    if (actions.logOpen && event.name === 'c') {
+      if (!actions.cancelActiveLogJob()) {
+        showStatus('No running action selected to cancel', 'error')
+      }
+      return
+    }
+
     switch (event.name) {
       case 'j':
       case 'down':
@@ -562,6 +570,7 @@ export function Dashboard({
                     { key: 'a', action: 'archive' },
                     { key: 'l', action: 'log' },
                     { key: '[ ]', action: 'cycle jobs' },
+                    { key: 'c', action: 'cancel job' },
                     { key: 'r', action: 'refresh' },
                     { key: 'q', action: 'quit' },
                   ]

--- a/src/tui/views/Dashboard.tsx
+++ b/src/tui/views/Dashboard.tsx
@@ -3,11 +3,10 @@ import { useKeyboard } from '@opentui/react'
 import type { ScrollBoxRenderable } from '@opentui/core'
 import type { PortConfig, HostService } from '../../types.ts'
 import type { WorktreeStatus } from '../../lib/worktreeStatus.ts'
-import type { ActionJob, EnqueueResult } from '../hooks/useActions.ts'
+import type { ActionJob, EnqueueResult, OutputTailLine } from '../hooks/useActions.ts'
 import { StatusIndicator } from '../components/StatusIndicator.tsx'
 import { KeyHints } from '../components/KeyHints.tsx'
 import { Confirm } from '../components/Confirm.tsx'
-import { ActionLog } from '../components/ActionLog.tsx'
 
 interface Actions {
   upWorktree: (worktreePath: string, worktreeName: string) => EnqueueResult
@@ -15,13 +14,8 @@ interface Actions {
   archiveWorktree: (worktreePath: string, worktreeName: string) => EnqueueResult
   isWorktreeBusy: (worktreeName: string) => boolean
   latestJobByWorktree: Map<string, ActionJob>
-  jobs: ActionJob[]
-  logOpen: boolean
-  activeLogJob: ActionJob | null
-  toggleLog: () => void
-  selectNextLogJob: () => void
-  selectPrevLogJob: () => void
-  cancelActiveLogJob: () => boolean
+  getOutputTail: (worktreeName: string) => OutputTailLine[]
+  cancelWorktreeAction: (worktreeName: string) => boolean
 }
 
 interface DashboardProps {
@@ -140,6 +134,46 @@ function buildHighlightedSegments(text: string, ranges: MatchRange[]): React.Rea
   return segments
 }
 
+function formatElapsedSeconds(job: ActionJob): string | null {
+  if (typeof job.startedAt !== 'number' || typeof job.endedAt !== 'number') {
+    return null
+  }
+  const seconds = Math.max(1, Math.round((job.endedAt - job.startedAt) / 1000))
+  return `${seconds}s`
+}
+
+function formatOutputTitle(
+  worktreeName: string,
+  latestJob: ActionJob | undefined,
+  running: boolean
+): string {
+  const base = `Output (${worktreeName})`
+  if (!latestJob) {
+    return running ? `${base} - running` : base
+  }
+
+  if (running || latestJob.status === 'running') {
+    return `${base} - running`
+  }
+
+  const elapsed = formatElapsedSeconds(latestJob)
+  if (!elapsed) {
+    return base
+  }
+
+  if (latestJob.status === 'success') {
+    return `${base} - finished in ${elapsed}`
+  }
+  if (latestJob.status === 'error') {
+    return `${base} - failed in ${elapsed}`
+  }
+  if (latestJob.status === 'cancelled') {
+    return `${base} - cancelled in ${elapsed}`
+  }
+
+  return base
+}
+
 export function Dashboard({
   repoName,
   worktrees,
@@ -222,6 +256,12 @@ export function Dashboard({
   }
 
   const selectedWorktree = worktrees[selectedIndex]
+  const selectedLatestJob = selectedWorktree
+    ? actions.latestJobByWorktree.get(selectedWorktree.name)
+    : undefined
+  const selectedRunningAction = selectedWorktree
+    ? actions.isWorktreeBusy(selectedWorktree.name)
+    : false
   const isRootSelected = selectedIndex === 0
   const highlightQuery =
     jumpMode === 'query' ? draftQuery : jumpMode === 'filtered-nav' ? appliedQuery : ''
@@ -308,26 +348,8 @@ export function Dashboard({
       }
     }
 
-    const isPrevLogKey = event.name === '[' || event.name === 'openbracket' || keySequence === '['
-    const isNextLogKey = event.name === ']' || event.name === 'closebracket' || keySequence === ']'
-
-    if (event.name === 'l') {
-      actions.toggleLog()
-      return
-    }
-
-    if (actions.logOpen && isPrevLogKey) {
-      actions.selectPrevLogJob()
-      return
-    }
-
-    if (actions.logOpen && isNextLogKey) {
-      actions.selectNextLogJob()
-      return
-    }
-
-    if (actions.logOpen && event.name === 'c') {
-      if (!actions.cancelActiveLogJob()) {
+    if (event.name === 'c' && selectedWorktree) {
+      if (!actions.cancelWorktreeAction(selectedWorktree.name)) {
         showStatus('No running action selected to cancel', 'error')
       }
       return
@@ -462,6 +484,16 @@ export function Dashboard({
               <text flexShrink={1} wrapMode="none">
                 {matchRanges.length > 0 ? buildHighlightedSegments(nameStr, matchRanges) : nameStr}
               </text>
+              {runningAction && latestJob && (
+                <text wrapMode="none" flexShrink={0} fg="#FFFF00">
+                  {'  ' + latestJob.kind + '...'}
+                </text>
+              )}
+              {!runningAction && latestJob?.status === 'error' && (
+                <text wrapMode="none" flexShrink={0} fg="#FF4444">
+                  {'  ' + latestJob.kind + ' failed'}
+                </text>
+              )}
               {totalCount === 0 && loading && (
                 <text wrapMode="none" flexShrink={0} fg="#555555">
                   {' ...'}
@@ -482,16 +514,6 @@ export function Dashboard({
                   {'  ' + totalCount + ' total'}
                 </text>
               )}
-              {runningAction && latestJob && (
-                <text wrapMode="none" flexShrink={0} fg="#FFFF00">
-                  {'  ' + latestJob.kind + '...'}
-                </text>
-              )}
-              {!runningAction && latestJob?.status === 'error' && (
-                <text wrapMode="none" flexShrink={0} fg="#FF4444">
-                  {'  ' + latestJob.kind + ' failed'}
-                </text>
-              )}
             </box>
           )
         })}
@@ -506,12 +528,27 @@ export function Dashboard({
         </text>
       )}
 
-      {actions.logOpen && (
-        <>
-          <box height={1} flexShrink={0} />
-          <ActionLog jobs={actions.jobs} activeJob={actions.activeLogJob} />
-        </>
-      )}
+      {selectedWorktree &&
+        (selectedRunningAction || actions.getOutputTail(selectedWorktree.name).length > 0) && (
+          <box flexDirection="column" flexShrink={0}>
+            <text fg="#888888">
+              <b>
+                {formatOutputTitle(selectedWorktree.name, selectedLatestJob, selectedRunningAction)}
+              </b>
+            </text>
+            {actions.getOutputTail(selectedWorktree.name).map((entry, index) => (
+              <text
+                key={`${selectedWorktree.name}-tail-${index}`}
+                fg={entry.stream === 'stderr' ? '#FF8888' : '#888888'}
+              >
+                {entry.line}
+              </text>
+            ))}
+            {actions.getOutputTail(selectedWorktree.name).length === 0 && (
+              <text fg="#666666">No output yet...</text>
+            )}
+          </box>
+        )}
 
       {/* Jump prompt */}
       {jumpMode !== 'normal' && (
@@ -568,9 +605,9 @@ export function Dashboard({
                     { key: 'u', action: 'up' },
                     { key: 'd', action: 'down' },
                     { key: 'a', action: 'archive' },
-                    { key: 'l', action: 'log' },
-                    { key: '[ ]', action: 'cycle jobs' },
-                    { key: 'c', action: 'cancel job' },
+                    ...(selectedWorktree && selectedRunningAction
+                      ? [{ key: 'c', action: 'cancel running' }]
+                      : []),
                     { key: 'r', action: 'refresh' },
                     { key: 'q', action: 'quit' },
                   ]

--- a/src/tui/views/Dashboard.tsx
+++ b/src/tui/views/Dashboard.tsx
@@ -142,6 +142,14 @@ function formatElapsedSeconds(job: ActionJob): string | null {
   return `${seconds}s`
 }
 
+function formatRunningSeconds(job: ActionJob): string | null {
+  if (typeof job.startedAt !== 'number') {
+    return null
+  }
+  const seconds = Math.max(1, Math.round((Date.now() - job.startedAt) / 1000))
+  return `${seconds}s`
+}
+
 function formatOutputTitle(
   worktreeName: string,
   latestJob: ActionJob | undefined,
@@ -153,7 +161,8 @@ function formatOutputTitle(
   }
 
   if (running || latestJob.status === 'running') {
-    return `${base} - running`
+    const elapsed = formatRunningSeconds(latestJob)
+    return elapsed ? `${base} - running for ${elapsed}` : `${base} - running`
   }
 
   const elapsed = formatElapsedSeconds(latestJob)
@@ -266,6 +275,14 @@ export function Dashboard({
   const highlightQuery =
     jumpMode === 'query' ? draftQuery : jumpMode === 'filtered-nav' ? appliedQuery : ''
   const highlightMatches = findMatchingIndices(worktrees, highlightQuery)
+  const selectedOutputTail = selectedWorktree ? actions.getOutputTail(selectedWorktree.name) : []
+  const selectedOutputLines =
+    selectedLatestJob?.logs
+      .filter(entry => entry.stream === 'stdout' || entry.stream === 'stderr')
+      .map(entry => ({ stream: entry.stream, line: entry.line })) ?? selectedOutputTail
+  const showOutput = Boolean(
+    selectedWorktree && (selectedRunningAction || selectedOutputTail.length > 0)
+  )
   useKeyboard(event => {
     if (event.ctrl || event.meta) return
 
@@ -447,7 +464,7 @@ export function Dashboard({
       {/* Worktree rows */}
       <scrollbox
         ref={scrollRef}
-        flexGrow={1}
+        flexGrow={0}
         flexShrink={1}
         scrollY
         scrollX={false}
@@ -523,52 +540,62 @@ export function Dashboard({
 
       {/* Status message */}
       {statusMessage && (
-        <text fg={statusMessage.type === 'success' ? '#00FF00' : '#FF4444'}>
+        <text fg={statusMessage.type === 'success' ? '#00FF00' : '#FF4444'} flexShrink={0}>
           {statusMessage.text}
         </text>
       )}
 
-      {selectedWorktree &&
-        (selectedRunningAction || actions.getOutputTail(selectedWorktree.name).length > 0) && (
-          <box flexDirection="column" flexShrink={0}>
-            <text fg="#888888">
-              <b>
-                {formatOutputTitle(selectedWorktree.name, selectedLatestJob, selectedRunningAction)}
-              </b>
-            </text>
-            {actions.getOutputTail(selectedWorktree.name).map((entry, index) => (
+      {showOutput && selectedWorktree && (
+        <box flexDirection="column" flexGrow={1} flexShrink={1} minHeight={3}>
+          <box height={1} flexShrink={0} />
+          <text fg="#888888" flexShrink={0}>
+            <b>
+              {formatOutputTitle(selectedWorktree.name, selectedLatestJob, selectedRunningAction)}
+            </b>
+          </text>
+          <scrollbox
+            flexGrow={1}
+            flexShrink={1}
+            scrollY
+            scrollX={false}
+            contentOptions={{ flexDirection: 'column', width: '100%' }}
+          >
+            {selectedOutputLines.map((entry, index) => (
               <text
-                key={`${selectedWorktree.name}-tail-${index}`}
+                key={`${selectedWorktree.name}-output-${index}`}
                 fg={entry.stream === 'stderr' ? '#FF8888' : '#888888'}
               >
                 {entry.line}
               </text>
             ))}
-            {actions.getOutputTail(selectedWorktree.name).length === 0 && (
-              <text fg="#666666">No output yet...</text>
-            )}
-          </box>
-        )}
+            {selectedOutputLines.length === 0 && <text fg="#666666">No output yet...</text>}
+          </scrollbox>
+        </box>
+      )}
 
       {/* Jump prompt */}
-      {jumpMode !== 'normal' && (
-        <text
-          fg={
-            jumpMode === 'query'
+      <text
+        flexShrink={0}
+        fg={
+          jumpMode === 'normal'
+            ? '#333333'
+            : jumpMode === 'query'
               ? highlightQuery.length === 0
                 ? '#888888'
                 : highlightMatches.length > 0
                   ? '#00AAFF'
                   : '#FFAA00'
               : '#00AAFF'
-          }
-        >
-          /{highlightQuery}{' '}
-          {highlightQuery.length === 0
-            ? '(type to filter)'
-            : `(${highlightMatches.length} match${highlightMatches.length === 1 ? '' : 'es'})`}
-        </text>
-      )}
+        }
+      >
+        {jumpMode === 'normal'
+          ? ' '
+          : `/${highlightQuery} ${
+              highlightQuery.length === 0
+                ? '(type to filter)'
+                : `(${highlightMatches.length} match${highlightMatches.length === 1 ? '' : 'es'})`
+            }`}
+      </text>
 
       {/* Confirmation dialog */}
       {pendingAction === 'archive' && selectedWorktree && (
@@ -581,38 +608,40 @@ export function Dashboard({
 
       {/* Key hints */}
       {!pendingAction && (
-        <KeyHints
-          hints={
-            jumpMode === 'query'
-              ? [
-                  { key: 'Type', action: 'filter' },
-                  { key: 'Backspace', action: 'delete' },
-                  { key: 'Enter', action: 'apply' },
-                  { key: 'Esc', action: 'cancel' },
-                ]
-              : jumpMode === 'filtered-nav'
+        <box flexShrink={0}>
+          <KeyHints
+            hints={
+              jumpMode === 'query'
                 ? [
-                    { key: 'j/k', action: 'next/prev match' },
-                    { key: '/', action: 'edit filter' },
-                    { key: 'Esc', action: 'clear filter' },
-                    { key: 'Enter', action: 'inspect' },
-                    { key: 'o', action: 'open' },
+                    { key: 'Type', action: 'filter' },
+                    { key: 'Backspace', action: 'delete' },
+                    { key: 'Enter', action: 'apply' },
+                    { key: 'Esc', action: 'cancel' },
                   ]
-                : [
-                    { key: 'Enter', action: 'inspect' },
-                    { key: 'o', action: 'open' },
-                    { key: '/', action: 'filter' },
-                    { key: 'u', action: 'up' },
-                    { key: 'd', action: 'down' },
-                    { key: 'a', action: 'archive' },
-                    ...(selectedWorktree && selectedRunningAction
-                      ? [{ key: 'c', action: 'cancel running' }]
-                      : []),
-                    { key: 'r', action: 'refresh' },
-                    { key: 'q', action: 'quit' },
-                  ]
-          }
-        />
+                : jumpMode === 'filtered-nav'
+                  ? [
+                      { key: 'j/k', action: 'next/prev match' },
+                      { key: '/', action: 'edit filter' },
+                      { key: 'Esc', action: 'clear filter' },
+                      { key: 'Enter', action: 'inspect' },
+                      { key: 'o', action: 'open' },
+                    ]
+                  : [
+                      { key: 'Enter', action: 'inspect' },
+                      { key: 'o', action: 'open' },
+                      { key: '/', action: 'filter' },
+                      { key: 'u', action: 'up' },
+                      { key: 'd', action: 'down' },
+                      { key: 'a', action: 'archive' },
+                      ...(selectedWorktree && selectedRunningAction
+                        ? [{ key: 'c', action: 'cancel running' }]
+                        : []),
+                      { key: 'r', action: 'refresh' },
+                      { key: 'q', action: 'quit' },
+                    ]
+            }
+          />
+        </box>
       )}
     </box>
   )

--- a/src/tui/views/Dashboard.tsx
+++ b/src/tui/views/Dashboard.tsx
@@ -7,6 +7,7 @@ import type { ActionJob, EnqueueResult } from '../hooks/useActions.ts'
 import { StatusIndicator } from '../components/StatusIndicator.tsx'
 import { KeyHints } from '../components/KeyHints.tsx'
 import { Confirm } from '../components/Confirm.tsx'
+import { ActionLog } from '../components/ActionLog.tsx'
 
 interface Actions {
   upWorktree: (worktreePath: string, worktreeName: string) => EnqueueResult
@@ -14,6 +15,12 @@ interface Actions {
   archiveWorktree: (worktreePath: string, worktreeName: string) => EnqueueResult
   isWorktreeBusy: (worktreeName: string) => boolean
   latestJobByWorktree: Map<string, ActionJob>
+  jobs: ActionJob[]
+  logOpen: boolean
+  activeLogJob: ActionJob | null
+  toggleLog: () => void
+  selectNextLogJob: () => void
+  selectPrevLogJob: () => void
 }
 
 interface DashboardProps {
@@ -300,6 +307,24 @@ export function Dashboard({
       }
     }
 
+    const isPrevLogKey = event.name === '[' || event.name === 'openbracket' || keySequence === '['
+    const isNextLogKey = event.name === ']' || event.name === 'closebracket' || keySequence === ']'
+
+    if (event.name === 'l') {
+      actions.toggleLog()
+      return
+    }
+
+    if (actions.logOpen && isPrevLogKey) {
+      actions.selectPrevLogJob()
+      return
+    }
+
+    if (actions.logOpen && isNextLogKey) {
+      actions.selectNextLogJob()
+      return
+    }
+
     switch (event.name) {
       case 'j':
       case 'down':
@@ -473,6 +498,13 @@ export function Dashboard({
         </text>
       )}
 
+      {actions.logOpen && (
+        <>
+          <box height={1} flexShrink={0} />
+          <ActionLog jobs={actions.jobs} activeJob={actions.activeLogJob} />
+        </>
+      )}
+
       {/* Jump prompt */}
       {jumpMode !== 'normal' && (
         <text
@@ -528,6 +560,8 @@ export function Dashboard({
                     { key: 'u', action: 'up' },
                     { key: 'd', action: 'down' },
                     { key: 'a', action: 'archive' },
+                    { key: 'l', action: 'log' },
+                    { key: '[ ]', action: 'cycle jobs' },
                     { key: 'r', action: 'refresh' },
                     { key: 'q', action: 'quit' },
                   ]

--- a/src/tui/views/Dashboard.tsx
+++ b/src/tui/views/Dashboard.tsx
@@ -207,6 +207,7 @@ export function Dashboard({
   const [draftQuery, setDraftQuery] = useState('')
   const initialSelectionAppliedRef = useRef(false)
   const scrollRef = useRef<ScrollBoxRenderable>(null)
+  const outputScrollRef = useRef<ScrollBoxRenderable>(null)
 
   // Keep selected row visible inside the scrollbox
   useEffect(() => {
@@ -283,6 +284,20 @@ export function Dashboard({
   const showOutput = Boolean(
     selectedWorktree && (selectedRunningAction || selectedOutputTail.length > 0)
   )
+
+  useEffect(() => {
+    if (!selectedWorktree || !selectedRunningAction) {
+      return
+    }
+
+    const sb = outputScrollRef.current
+    if (!sb) {
+      return
+    }
+
+    sb.scrollTop = Number.MAX_SAFE_INTEGER
+  }, [selectedOutputLines.length, selectedRunningAction, selectedWorktree])
+
   useKeyboard(event => {
     if (event.ctrl || event.meta) return
 
@@ -554,6 +569,12 @@ export function Dashboard({
             </b>
           </text>
           <scrollbox
+            ref={node => {
+              outputScrollRef.current = node
+              if (node && selectedRunningAction) {
+                node.scrollTop = Number.MAX_SAFE_INTEGER
+              }
+            }}
             flexGrow={1}
             flexShrink={1}
             scrollY

--- a/src/tui/views/Dashboard.tsx
+++ b/src/tui/views/Dashboard.tsx
@@ -713,7 +713,6 @@ export function Dashboard({
                       { key: 'Enter', action: 'inspect' },
                       { key: 'o', action: 'open' },
                       { key: '/', action: 'filter' },
-                      { key: 'l', action: 'toggle output' },
                       { key: 'u', action: 'up' },
                       { key: 'd', action: 'down' },
                       { key: 'a', action: 'archive' },

--- a/src/tui/views/Dashboard.tsx
+++ b/src/tui/views/Dashboard.tsx
@@ -3,15 +3,17 @@ import { useKeyboard } from '@opentui/react'
 import type { ScrollBoxRenderable } from '@opentui/core'
 import type { PortConfig, HostService } from '../../types.ts'
 import type { WorktreeStatus } from '../../lib/worktreeStatus.ts'
-import type { ActionResult } from '../hooks/useActions.ts'
+import type { ActionJob, EnqueueResult } from '../hooks/useActions.ts'
 import { StatusIndicator } from '../components/StatusIndicator.tsx'
 import { KeyHints } from '../components/KeyHints.tsx'
 import { Confirm } from '../components/Confirm.tsx'
 
 interface Actions {
-  upWorktree: (worktreePath: string, worktreeName: string) => Promise<ActionResult>
-  downWorktree: (worktreePath: string, worktreeName: string) => Promise<ActionResult>
-  archiveWorktree: (worktreePath: string, worktreeName: string) => Promise<ActionResult>
+  upWorktree: (worktreePath: string, worktreeName: string) => EnqueueResult
+  downWorktree: (worktreePath: string, worktreeName: string) => EnqueueResult
+  archiveWorktree: (worktreePath: string, worktreeName: string) => EnqueueResult
+  isWorktreeBusy: (worktreeName: string) => boolean
+  latestJobByWorktree: Map<string, ActionJob>
 }
 
 interface DashboardProps {
@@ -149,7 +151,6 @@ export function Dashboard({
     return idx >= 0 ? idx : 0
   })
   const [pendingAction, setPendingAction] = useState<PendingAction>(null)
-  const [busy, setBusy] = useState(false)
   const [jumpMode, setJumpMode] = useState<JumpMode>('normal')
   const [appliedQuery, setAppliedQuery] = useState('')
   const [draftQuery, setDraftQuery] = useState('')
@@ -218,7 +219,7 @@ export function Dashboard({
     jumpMode === 'query' ? draftQuery : jumpMode === 'filtered-nav' ? appliedQuery : ''
   const highlightMatches = findMatchingIndices(worktrees, highlightQuery)
   useKeyboard(event => {
-    if (event.ctrl || event.meta || busy) return
+    if (event.ctrl || event.meta) return
 
     const keySequence = (event as { sequence?: string }).sequence
     const maxIndex = worktrees.length - 1
@@ -315,24 +316,18 @@ export function Dashboard({
         break
       case 'u':
         if (selectedWorktree) {
-          setBusy(true)
-          actions
-            .upWorktree(selectedWorktree.path, selectedWorktree.name)
-            .then(result => {
-              showStatus(result.message, result.success ? 'success' : 'error')
-            })
-            .finally(() => setBusy(false))
+          const result = actions.upWorktree(selectedWorktree.path, selectedWorktree.name)
+          if (!result.accepted) {
+            showStatus(result.message, 'error')
+          }
         }
         break
       case 'd':
         if (selectedWorktree) {
-          setBusy(true)
-          actions
-            .downWorktree(selectedWorktree.path, selectedWorktree.name)
-            .then(result => {
-              showStatus(result.message, result.success ? 'success' : 'error')
-            })
-            .finally(() => setBusy(false))
+          const result = actions.downWorktree(selectedWorktree.path, selectedWorktree.name)
+          if (!result.accepted) {
+            showStatus(result.message, 'error')
+          }
         }
         break
       case 'o':
@@ -351,17 +346,17 @@ export function Dashboard({
   const handleConfirmArchive = () => {
     if (!selectedWorktree) return
     setPendingAction(null)
-    setBusy(true)
-    actions
-      .archiveWorktree(selectedWorktree.path, selectedWorktree.name)
-      .then(result => {
-        showStatus(result.message, result.success ? 'success' : 'error')
-        // Adjust selection if needed
-        if (selectedIndex >= worktrees.length - 1) {
-          setSelectedIndex(Math.max(0, worktrees.length - 2))
-        }
-      })
-      .finally(() => setBusy(false))
+
+    const result = actions.archiveWorktree(selectedWorktree.path, selectedWorktree.name)
+    if (!result.accepted) {
+      showStatus(result.message, 'error')
+      return
+    }
+
+    // Optimistically adjust selection while archive runs.
+    if (selectedIndex >= worktrees.length - 1) {
+      setSelectedIndex(Math.max(0, worktrees.length - 2))
+    }
   }
 
   const handleCancelAction = () => {
@@ -376,7 +371,6 @@ export function Dashboard({
           <b>port: {repoName}</b>
         </text>
         {loading && <text fg="#888888"> refreshing...</text>}
-        {busy && <text fg="#FFFF00"> working...</text>}
       </box>
 
       <box height={1} flexShrink={0} />
@@ -419,6 +413,8 @@ export function Dashboard({
           const matchRanges = highlightQuery
             ? findSubstringMatchRanges(nameStr, highlightQuery)
             : []
+          const latestJob = actions.latestJobByWorktree.get(worktree.name)
+          const runningAction = actions.isWorktreeBusy(worktree.name)
 
           return (
             <box key={worktree.name} flexDirection="row" height={1} overflow="hidden">
@@ -451,6 +447,16 @@ export function Dashboard({
               {totalCount > 0 && (
                 <text wrapMode="none" flexShrink={0} fg="#555555">
                   {'  ' + totalCount + ' total'}
+                </text>
+              )}
+              {runningAction && latestJob && (
+                <text wrapMode="none" flexShrink={0} fg="#FFFF00">
+                  {'  ' + latestJob.kind + '...'}
+                </text>
+              )}
+              {!runningAction && latestJob?.status === 'error' && (
+                <text wrapMode="none" flexShrink={0} fg="#FF4444">
+                  {'  ' + latestJob.kind + ' failed'}
                 </text>
               )}
             </box>

--- a/src/tui/views/Dashboard.tsx
+++ b/src/tui/views/Dashboard.tsx
@@ -15,6 +15,8 @@ interface Actions {
   isWorktreeBusy: (worktreeName: string) => boolean
   latestJobByWorktree: Map<string, ActionJob>
   getOutputTail: (worktreeName: string) => OutputTailLine[]
+  isOutputVisible: (worktreeName: string) => boolean
+  toggleOutputVisible: (worktreeName: string) => void
   cancelWorktreeAction: (worktreeName: string) => boolean
 }
 
@@ -183,6 +185,13 @@ function formatOutputTitle(
   return base
 }
 
+function isOutputEntry(entry: {
+  stream: 'stdout' | 'stderr' | 'system'
+  line: string
+}): entry is { stream: 'stdout' | 'stderr'; line: string } {
+  return entry.stream === 'stdout' || entry.stream === 'stderr'
+}
+
 export function Dashboard({
   repoName,
   worktrees,
@@ -279,11 +288,18 @@ export function Dashboard({
   const selectedOutputTail = selectedWorktree ? actions.getOutputTail(selectedWorktree.name) : []
   const selectedOutputLines =
     selectedLatestJob?.logs
-      .filter(entry => entry.stream === 'stdout' || entry.stream === 'stderr')
+      .filter(isOutputEntry)
       .map(entry => ({ stream: entry.stream, line: entry.line })) ?? selectedOutputTail
+  const selectedOutputVisible = selectedWorktree
+    ? actions.isOutputVisible(selectedWorktree.name)
+    : true
   const showOutput = Boolean(
-    selectedWorktree && (selectedRunningAction || selectedOutputTail.length > 0)
+    selectedWorktree &&
+    selectedOutputVisible &&
+    (selectedRunningAction || selectedOutputTail.length > 0 || selectedOutputLines.length > 0)
   )
+  const prevOutputVisibilityRef = useRef(false)
+  const prevOutputWorktreeRef = useRef<string | null>(null)
 
   useEffect(() => {
     if (!selectedWorktree || !selectedRunningAction) {
@@ -297,6 +313,26 @@ export function Dashboard({
 
     sb.scrollTop = Number.MAX_SAFE_INTEGER
   }, [selectedOutputLines.length, selectedRunningAction, selectedWorktree])
+
+  useEffect(() => {
+    const currentWorktree = selectedWorktree?.name ?? null
+    const visibilityChangedToShown = showOutput && !prevOutputVisibilityRef.current
+    const switchedWorktreeWhileVisible =
+      showOutput &&
+      prevOutputVisibilityRef.current &&
+      prevOutputWorktreeRef.current !== null &&
+      prevOutputWorktreeRef.current !== currentWorktree
+
+    if (visibilityChangedToShown || switchedWorktreeWhileVisible) {
+      const sb = outputScrollRef.current
+      if (sb) {
+        sb.scrollTop = Number.MAX_SAFE_INTEGER
+      }
+    }
+
+    prevOutputVisibilityRef.current = showOutput
+    prevOutputWorktreeRef.current = currentWorktree
+  }, [showOutput, selectedWorktree])
 
   useKeyboard(event => {
     if (event.ctrl || event.meta) return
@@ -384,6 +420,11 @@ export function Dashboard({
       if (!actions.cancelWorktreeAction(selectedWorktree.name)) {
         showStatus('No running action selected to cancel', 'error')
       }
+      return
+    }
+
+    if (event.name === 'l' && selectedWorktree) {
+      actions.toggleOutputVisible(selectedWorktree.name)
       return
     }
 
@@ -566,7 +607,8 @@ export function Dashboard({
           <text fg="#888888" flexShrink={0}>
             <b>
               {formatOutputTitle(selectedWorktree.name, selectedLatestJob, selectedRunningAction)}
-            </b>
+            </b>{' '}
+            <span fg="#CCCCCC">[l]</span> toggle
           </text>
           <scrollbox
             ref={node => {
@@ -651,6 +693,7 @@ export function Dashboard({
                       { key: 'Enter', action: 'inspect' },
                       { key: 'o', action: 'open' },
                       { key: '/', action: 'filter' },
+                      { key: 'l', action: 'toggle output' },
                       { key: 'u', action: 'up' },
                       { key: 'd', action: 'down' },
                       { key: 'a', action: 'archive' },

--- a/src/tui/views/Dashboard.tsx
+++ b/src/tui/views/Dashboard.tsx
@@ -293,10 +293,16 @@ export function Dashboard({
   const selectedOutputVisible = selectedWorktree
     ? actions.isOutputVisible(selectedWorktree.name)
     : true
-  const showOutput = Boolean(
+  const hasOutputContext = Boolean(
     selectedWorktree &&
-    selectedOutputVisible &&
-    (selectedRunningAction || selectedOutputTail.length > 0 || selectedOutputLines.length > 0)
+    (selectedRunningAction ||
+      selectedOutputTail.length > 0 ||
+      selectedOutputLines.length > 0 ||
+      selectedLatestJob)
+  )
+  const showOutput = Boolean(selectedWorktree && selectedOutputVisible && hasOutputContext)
+  const showOutputPlaceholder = Boolean(
+    selectedWorktree && !selectedOutputVisible && hasOutputContext
   )
   const prevOutputVisibilityRef = useRef(false)
   const prevOutputWorktreeRef = useRef<string | null>(null)
@@ -611,7 +617,7 @@ export function Dashboard({
               <b>
                 {formatOutputTitle(selectedWorktree.name, selectedLatestJob, selectedRunningAction)}
               </b>{' '}
-              <span fg="#CCCCCC">[l]</span> toggle
+              <span fg="#CCCCCC">[l]</span> hide
             </text>
             <scrollbox
               ref={node => {
@@ -638,6 +644,15 @@ export function Dashboard({
               {selectedOutputLines.length === 0 && <text fg="#666666">No output yet...</text>}
             </scrollbox>
           </box>
+        )}
+
+        {showOutputPlaceholder && selectedWorktree && (
+          <text fg="#888888" flexShrink={0}>
+            <b>
+              {formatOutputTitle(selectedWorktree.name, selectedLatestJob, selectedRunningAction)}
+            </b>{' '}
+            <span fg="#CCCCCC">[l]</span> show
+          </text>
         )}
       </box>
 

--- a/src/tui/views/WorktreeView.tsx
+++ b/src/tui/views/WorktreeView.tsx
@@ -13,6 +13,8 @@ interface Actions {
   isWorktreeBusy: (worktreeName: string) => boolean
   latestJobByWorktree: Map<string, ActionJob>
   getOutputTail: (worktreeName: string) => OutputTailLine[]
+  isOutputVisible: (worktreeName: string) => boolean
+  toggleOutputVisible: (worktreeName: string) => void
   cancelWorktreeAction: (worktreeName: string) => boolean
 }
 
@@ -138,6 +140,13 @@ function formatOutputTitle(
   return base
 }
 
+function isOutputEntry(entry: {
+  stream: 'stdout' | 'stderr' | 'system'
+  line: string
+}): entry is { stream: 'stdout' | 'stderr'; line: string } {
+  return entry.stream === 'stdout' || entry.stream === 'stderr'
+}
+
 export function WorktreeView({
   worktree,
   hostServices,
@@ -150,6 +159,7 @@ export function WorktreeView({
 }: WorktreeViewProps) {
   const [selectedIndex, setSelectedIndex] = useState(0)
   const scrollRef = useRef<ScrollBoxRenderable>(null)
+  const outputScrollRef = useRef<ScrollBoxRenderable>(null)
 
   // Keep selected service visible inside the scrollbox.
   // Estimate the content line for the selected item accounting for section
@@ -205,9 +215,23 @@ export function WorktreeView({
   const services = buildServiceItems(worktree, hostServices, config, worktreeName)
   const latestJob = actions.latestJobByWorktree.get(worktreeName)
   const runningAction = actions.isWorktreeBusy(worktreeName)
+  const outputTail = actions.getOutputTail(worktreeName)
+  const outputLines =
+    latestJob?.logs
+      .filter(isOutputEntry)
+      .map(entry => ({ stream: entry.stream, line: entry.line })) ?? outputTail
+  const outputVisible = actions.isOutputVisible(worktreeName)
+  const showOutput =
+    outputVisible && (runningAction || outputTail.length > 0 || outputLines.length > 0)
+  const prevOutputVisibleRef = useRef(false)
 
   useKeyboard(event => {
     if (event.ctrl || event.meta) return
+
+    if (event.name === 'l') {
+      actions.toggleOutputVisible(worktreeName)
+      return
+    }
 
     if (event.name === 'c') {
       if (!actions.cancelWorktreeAction(worktreeName)) {
@@ -266,6 +290,23 @@ export function WorktreeView({
     }
   })
 
+  useEffect(() => {
+    if (!showOutput) {
+      prevOutputVisibleRef.current = false
+      return
+    }
+
+    const shouldJump = !prevOutputVisibleRef.current || runningAction
+    if (shouldJump) {
+      const sb = outputScrollRef.current
+      if (sb) {
+        sb.scrollTop = Number.MAX_SAFE_INTEGER
+      }
+    }
+
+    prevOutputVisibleRef.current = true
+  }, [showOutput, runningAction, outputLines.length])
+
   return (
     <box flexDirection="column" width="100%" height="100%">
       {/* Header */}
@@ -287,22 +328,29 @@ export function WorktreeView({
 
       <box height={1} flexShrink={0} />
 
-      {(runningAction || actions.getOutputTail(worktreeName).length > 0) && (
+      {showOutput && (
         <box flexDirection="column" flexShrink={0}>
           <text fg="#888888">
-            <b>{formatOutputTitle(worktreeName, latestJob, runningAction)}</b>
+            <b>{formatOutputTitle(worktreeName, latestJob, runningAction)}</b>{' '}
+            <span fg="#CCCCCC">[l]</span> toggle
           </text>
-          {actions.getOutputTail(worktreeName).map((entry, index) => (
-            <text
-              key={`${worktreeName}-tail-${index}`}
-              fg={entry.stream === 'stderr' ? '#FF8888' : '#888888'}
-            >
-              {entry.line}
-            </text>
-          ))}
-          {actions.getOutputTail(worktreeName).length === 0 && (
-            <text fg="#666666">No output yet...</text>
-          )}
+          <scrollbox
+            ref={outputScrollRef}
+            height={3}
+            scrollY
+            scrollX={false}
+            contentOptions={{ flexDirection: 'column', width: '100%' }}
+          >
+            {outputLines.map((entry, index) => (
+              <text
+                key={`${worktreeName}-tail-${index}`}
+                fg={entry.stream === 'stderr' ? '#FF8888' : '#888888'}
+              >
+                {entry.line}
+              </text>
+            ))}
+            {outputLines.length === 0 && <text fg="#666666">No output yet...</text>}
+          </scrollbox>
         </box>
       )}
 
@@ -391,6 +439,7 @@ export function WorktreeView({
       <KeyHints
         hints={[
           { key: 'Enter', action: 'open in browser' },
+          { key: 'l', action: 'toggle output' },
           { key: 'd', action: 'down' },
           { key: 'x', action: 'kill host svc' },
           ...(runningAction ? [{ key: 'c', action: 'cancel running' }] : []),

--- a/src/tui/views/WorktreeView.tsx
+++ b/src/tui/views/WorktreeView.tsx
@@ -448,7 +448,6 @@ export function WorktreeView({
       <KeyHints
         hints={[
           { key: 'Enter', action: 'open in browser' },
-          { key: 'l', action: 'toggle output' },
           { key: 'd', action: 'down' },
           { key: 'x', action: 'kill host svc' },
           ...(runningAction ? [{ key: 'c', action: 'cancel running' }] : []),

--- a/src/tui/views/WorktreeView.tsx
+++ b/src/tui/views/WorktreeView.tsx
@@ -3,23 +3,17 @@ import { useKeyboard } from '@opentui/react'
 import type { ScrollBoxRenderable } from '@opentui/core'
 import type { PortConfig, HostService } from '../../types.ts'
 import type { WorktreeStatus } from '../../lib/worktreeStatus.ts'
-import type { ActionJob, EnqueueResult } from '../hooks/useActions.ts'
+import type { ActionJob, EnqueueResult, OutputTailLine } from '../hooks/useActions.ts'
 import { StatusIndicator } from '../components/StatusIndicator.tsx'
 import { KeyHints } from '../components/KeyHints.tsx'
-import { ActionLog } from '../components/ActionLog.tsx'
 
 interface Actions {
   downWorktree: (worktreePath: string, worktreeName: string) => EnqueueResult
   killHostService: (service: HostService) => EnqueueResult
   isWorktreeBusy: (worktreeName: string) => boolean
   latestJobByWorktree: Map<string, ActionJob>
-  jobs: ActionJob[]
-  logOpen: boolean
-  activeLogJob: ActionJob | null
-  toggleLog: () => void
-  selectNextLogJob: () => void
-  selectPrevLogJob: () => void
-  cancelActiveLogJob: () => boolean
+  getOutputTail: (worktreeName: string) => OutputTailLine[]
+  cancelWorktreeAction: (worktreeName: string) => boolean
 }
 
 interface WorktreeViewProps {
@@ -95,6 +89,46 @@ function buildServiceItems(
   return items
 }
 
+function formatElapsedSeconds(job: ActionJob): string | null {
+  if (typeof job.startedAt !== 'number' || typeof job.endedAt !== 'number') {
+    return null
+  }
+  const seconds = Math.max(1, Math.round((job.endedAt - job.startedAt) / 1000))
+  return `${seconds}s`
+}
+
+function formatOutputTitle(
+  worktreeName: string,
+  latestJob: ActionJob | undefined,
+  running: boolean
+): string {
+  const base = `Output (${worktreeName})`
+  if (!latestJob) {
+    return running ? `${base} - running` : base
+  }
+
+  if (running || latestJob.status === 'running') {
+    return `${base} - running`
+  }
+
+  const elapsed = formatElapsedSeconds(latestJob)
+  if (!elapsed) {
+    return base
+  }
+
+  if (latestJob.status === 'success') {
+    return `${base} - finished in ${elapsed}`
+  }
+  if (latestJob.status === 'error') {
+    return `${base} - failed in ${elapsed}`
+  }
+  if (latestJob.status === 'cancelled') {
+    return `${base} - cancelled in ${elapsed}`
+  }
+
+  return base
+}
+
 export function WorktreeView({
   worktree,
   hostServices,
@@ -166,27 +200,8 @@ export function WorktreeView({
   useKeyboard(event => {
     if (event.ctrl || event.meta) return
 
-    const keySequence = (event as { sequence?: string }).sequence
-    const isPrevLogKey = event.name === '[' || event.name === 'openbracket' || keySequence === '['
-    const isNextLogKey = event.name === ']' || event.name === 'closebracket' || keySequence === ']'
-
-    if (event.name === 'l') {
-      actions.toggleLog()
-      return
-    }
-
-    if (actions.logOpen && isPrevLogKey) {
-      actions.selectPrevLogJob()
-      return
-    }
-
-    if (actions.logOpen && isNextLogKey) {
-      actions.selectNextLogJob()
-      return
-    }
-
-    if (actions.logOpen && event.name === 'c') {
-      if (!actions.cancelActiveLogJob()) {
+    if (event.name === 'c') {
+      if (!actions.cancelWorktreeAction(worktreeName)) {
         showStatus('No running action selected to cancel', 'error')
       }
       return
@@ -260,6 +275,27 @@ export function WorktreeView({
       <text fg="#00AAFF" flexShrink={0}>
         {baseUrl}
       </text>
+
+      <box height={1} flexShrink={0} />
+
+      {(runningAction || actions.getOutputTail(worktreeName).length > 0) && (
+        <box flexDirection="column" flexShrink={0}>
+          <text fg="#888888">
+            <b>{formatOutputTitle(worktreeName, latestJob, runningAction)}</b>
+          </text>
+          {actions.getOutputTail(worktreeName).map((entry, index) => (
+            <text
+              key={`${worktreeName}-tail-${index}`}
+              fg={entry.stream === 'stderr' ? '#FF8888' : '#888888'}
+            >
+              {entry.line}
+            </text>
+          ))}
+          {actions.getOutputTail(worktreeName).length === 0 && (
+            <text fg="#666666">No output yet...</text>
+          )}
+        </box>
+      )}
 
       <box height={1} flexShrink={0} />
 
@@ -342,22 +378,13 @@ export function WorktreeView({
         </text>
       )}
 
-      {actions.logOpen && (
-        <>
-          <box height={1} flexShrink={0} />
-          <ActionLog jobs={actions.jobs} activeJob={actions.activeLogJob} />
-        </>
-      )}
-
       {/* Key hints */}
       <KeyHints
         hints={[
           { key: 'Enter', action: 'open in browser' },
           { key: 'd', action: 'down' },
           { key: 'x', action: 'kill host svc' },
-          { key: 'l', action: 'log' },
-          { key: '[ ]', action: 'cycle jobs' },
-          { key: 'c', action: 'cancel job' },
+          ...(runningAction ? [{ key: 'c', action: 'cancel running' }] : []),
           { key: 'Esc', action: 'back' },
           { key: 'r', action: 'refresh' },
           { key: 'q', action: 'quit' },

--- a/src/tui/views/WorktreeView.tsx
+++ b/src/tui/views/WorktreeView.tsx
@@ -97,6 +97,14 @@ function formatElapsedSeconds(job: ActionJob): string | null {
   return `${seconds}s`
 }
 
+function formatRunningSeconds(job: ActionJob): string | null {
+  if (typeof job.startedAt !== 'number') {
+    return null
+  }
+  const seconds = Math.max(1, Math.round((Date.now() - job.startedAt) / 1000))
+  return `${seconds}s`
+}
+
 function formatOutputTitle(
   worktreeName: string,
   latestJob: ActionJob | undefined,
@@ -108,7 +116,8 @@ function formatOutputTitle(
   }
 
   if (running || latestJob.status === 'running') {
-    return `${base} - running`
+    const elapsed = formatRunningSeconds(latestJob)
+    return elapsed ? `${base} - running for ${elapsed}` : `${base} - running`
   }
 
   const elapsed = formatElapsedSeconds(latestJob)

--- a/src/tui/views/WorktreeView.tsx
+++ b/src/tui/views/WorktreeView.tsx
@@ -19,6 +19,7 @@ interface Actions {
   toggleLog: () => void
   selectNextLogJob: () => void
   selectPrevLogJob: () => void
+  cancelActiveLogJob: () => boolean
 }
 
 interface WorktreeViewProps {
@@ -181,6 +182,13 @@ export function WorktreeView({
 
     if (actions.logOpen && isNextLogKey) {
       actions.selectNextLogJob()
+      return
+    }
+
+    if (actions.logOpen && event.name === 'c') {
+      if (!actions.cancelActiveLogJob()) {
+        showStatus('No running action selected to cancel', 'error')
+      }
       return
     }
 
@@ -349,6 +357,7 @@ export function WorktreeView({
           { key: 'x', action: 'kill host svc' },
           { key: 'l', action: 'log' },
           { key: '[ ]', action: 'cycle jobs' },
+          { key: 'c', action: 'cancel job' },
           { key: 'Esc', action: 'back' },
           { key: 'r', action: 'refresh' },
           { key: 'q', action: 'quit' },

--- a/src/tui/views/WorktreeView.tsx
+++ b/src/tui/views/WorktreeView.tsx
@@ -221,8 +221,10 @@ export function WorktreeView({
       .filter(isOutputEntry)
       .map(entry => ({ stream: entry.stream, line: entry.line })) ?? outputTail
   const outputVisible = actions.isOutputVisible(worktreeName)
-  const showOutput =
-    outputVisible && (runningAction || outputTail.length > 0 || outputLines.length > 0)
+  const hasOutputContext =
+    runningAction || outputTail.length > 0 || outputLines.length > 0 || Boolean(latestJob)
+  const showOutput = outputVisible && hasOutputContext
+  const showOutputPlaceholder = !outputVisible && hasOutputContext
   const prevOutputVisibleRef = useRef(false)
 
   useKeyboard(event => {
@@ -332,7 +334,7 @@ export function WorktreeView({
         <box flexDirection="column" flexShrink={0}>
           <text fg="#888888">
             <b>{formatOutputTitle(worktreeName, latestJob, runningAction)}</b>{' '}
-            <span fg="#CCCCCC">[l]</span> toggle
+            <span fg="#CCCCCC">[l]</span> hide
           </text>
           <scrollbox
             ref={outputScrollRef}
@@ -352,6 +354,13 @@ export function WorktreeView({
             {outputLines.length === 0 && <text fg="#666666">No output yet...</text>}
           </scrollbox>
         </box>
+      )}
+
+      {showOutputPlaceholder && (
+        <text fg="#888888" flexShrink={0}>
+          <b>{formatOutputTitle(worktreeName, latestJob, runningAction)}</b>{' '}
+          <span fg="#CCCCCC">[l]</span> show
+        </text>
       )}
 
       <box height={1} flexShrink={0} />

--- a/src/tui/views/WorktreeView.tsx
+++ b/src/tui/views/WorktreeView.tsx
@@ -6,12 +6,19 @@ import type { WorktreeStatus } from '../../lib/worktreeStatus.ts'
 import type { ActionJob, EnqueueResult } from '../hooks/useActions.ts'
 import { StatusIndicator } from '../components/StatusIndicator.tsx'
 import { KeyHints } from '../components/KeyHints.tsx'
+import { ActionLog } from '../components/ActionLog.tsx'
 
 interface Actions {
   downWorktree: (worktreePath: string, worktreeName: string) => EnqueueResult
   killHostService: (service: HostService) => EnqueueResult
   isWorktreeBusy: (worktreeName: string) => boolean
   latestJobByWorktree: Map<string, ActionJob>
+  jobs: ActionJob[]
+  logOpen: boolean
+  activeLogJob: ActionJob | null
+  toggleLog: () => void
+  selectNextLogJob: () => void
+  selectPrevLogJob: () => void
 }
 
 interface WorktreeViewProps {
@@ -157,6 +164,25 @@ export function WorktreeView({
 
   useKeyboard(event => {
     if (event.ctrl || event.meta) return
+
+    const keySequence = (event as { sequence?: string }).sequence
+    const isPrevLogKey = event.name === '[' || event.name === 'openbracket' || keySequence === '['
+    const isNextLogKey = event.name === ']' || event.name === 'closebracket' || keySequence === ']'
+
+    if (event.name === 'l') {
+      actions.toggleLog()
+      return
+    }
+
+    if (actions.logOpen && isPrevLogKey) {
+      actions.selectPrevLogJob()
+      return
+    }
+
+    if (actions.logOpen && isNextLogKey) {
+      actions.selectNextLogJob()
+      return
+    }
 
     const maxIndex = Math.max(services.length - 1, 0)
 
@@ -308,12 +334,21 @@ export function WorktreeView({
         </text>
       )}
 
+      {actions.logOpen && (
+        <>
+          <box height={1} flexShrink={0} />
+          <ActionLog jobs={actions.jobs} activeJob={actions.activeLogJob} />
+        </>
+      )}
+
       {/* Key hints */}
       <KeyHints
         hints={[
           { key: 'Enter', action: 'open in browser' },
           { key: 'd', action: 'down' },
           { key: 'x', action: 'kill host svc' },
+          { key: 'l', action: 'log' },
+          { key: '[ ]', action: 'cycle jobs' },
           { key: 'Esc', action: 'back' },
           { key: 'r', action: 'refresh' },
           { key: 'q', action: 'quit' },

--- a/src/tui/views/WorktreeView.tsx
+++ b/src/tui/views/WorktreeView.tsx
@@ -330,41 +330,6 @@ export function WorktreeView({
 
       <box height={1} flexShrink={0} />
 
-      {showOutput && (
-        <box flexDirection="column" flexShrink={0}>
-          <text fg="#888888">
-            <b>{formatOutputTitle(worktreeName, latestJob, runningAction)}</b>{' '}
-            <span fg="#CCCCCC">[l]</span> hide
-          </text>
-          <scrollbox
-            ref={outputScrollRef}
-            height={3}
-            scrollY
-            scrollX={false}
-            contentOptions={{ flexDirection: 'column', width: '100%' }}
-          >
-            {outputLines.map((entry, index) => (
-              <text
-                key={`${worktreeName}-tail-${index}`}
-                fg={entry.stream === 'stderr' ? '#FF8888' : '#888888'}
-              >
-                {entry.line}
-              </text>
-            ))}
-            {outputLines.length === 0 && <text fg="#666666">No output yet...</text>}
-          </scrollbox>
-        </box>
-      )}
-
-      {showOutputPlaceholder && (
-        <text fg="#888888" flexShrink={0}>
-          <b>{formatOutputTitle(worktreeName, latestJob, runningAction)}</b>{' '}
-          <span fg="#CCCCCC">[l]</span> show
-        </text>
-      )}
-
-      <box height={1} flexShrink={0} />
-
       {/* Docker services header (always visible) */}
       {services.some(s => s.type === 'docker') && (
         <text fg="#888888" flexShrink={0}>
@@ -434,6 +399,41 @@ export function WorktreeView({
 
         {services.length === 0 && !loading && <text fg="#888888">No services configured</text>}
       </scrollbox>
+
+      {(showOutput || showOutputPlaceholder) && <box height={1} flexShrink={0} />}
+
+      {showOutput && (
+        <box flexDirection="column" flexShrink={0}>
+          <text fg="#888888">
+            <b>{formatOutputTitle(worktreeName, latestJob, runningAction)}</b>{' '}
+            <span fg="#CCCCCC">[l]</span> hide
+          </text>
+          <scrollbox
+            ref={outputScrollRef}
+            height={3}
+            scrollY
+            scrollX={false}
+            contentOptions={{ flexDirection: 'column', width: '100%' }}
+          >
+            {outputLines.map((entry, index) => (
+              <text
+                key={`${worktreeName}-tail-${index}`}
+                fg={entry.stream === 'stderr' ? '#FF8888' : '#888888'}
+              >
+                {entry.line}
+              </text>
+            ))}
+            {outputLines.length === 0 && <text fg="#666666">No output yet...</text>}
+          </scrollbox>
+        </box>
+      )}
+
+      {showOutputPlaceholder && (
+        <text fg="#888888" flexShrink={0}>
+          <b>{formatOutputTitle(worktreeName, latestJob, runningAction)}</b>{' '}
+          <span fg="#CCCCCC">[l]</span> show
+        </text>
+      )}
 
       <box height={1} flexShrink={0} />
 

--- a/src/tui/views/WorktreeView.tsx
+++ b/src/tui/views/WorktreeView.tsx
@@ -3,13 +3,15 @@ import { useKeyboard } from '@opentui/react'
 import type { ScrollBoxRenderable } from '@opentui/core'
 import type { PortConfig, HostService } from '../../types.ts'
 import type { WorktreeStatus } from '../../lib/worktreeStatus.ts'
-import type { ActionResult } from '../hooks/useActions.ts'
+import type { ActionJob, EnqueueResult } from '../hooks/useActions.ts'
 import { StatusIndicator } from '../components/StatusIndicator.tsx'
 import { KeyHints } from '../components/KeyHints.tsx'
 
 interface Actions {
-  downWorktree: (worktreePath: string, worktreeName: string) => Promise<ActionResult>
-  killHostService: (service: HostService) => Promise<ActionResult>
+  downWorktree: (worktreePath: string, worktreeName: string) => EnqueueResult
+  killHostService: (service: HostService) => EnqueueResult
+  isWorktreeBusy: (worktreeName: string) => boolean
+  latestJobByWorktree: Map<string, ActionJob>
 }
 
 interface WorktreeViewProps {
@@ -96,7 +98,6 @@ export function WorktreeView({
   showStatus,
 }: WorktreeViewProps) {
   const [selectedIndex, setSelectedIndex] = useState(0)
-  const [busy, setBusy] = useState(false)
   const scrollRef = useRef<ScrollBoxRenderable>(null)
 
   // Keep selected service visible inside the scrollbox.
@@ -151,9 +152,11 @@ export function WorktreeView({
   const worktreeName = worktree?.name ?? 'unknown'
   const baseUrl = `http://${worktreeName}.${config.domain}`
   const services = buildServiceItems(worktree, hostServices, config, worktreeName)
+  const latestJob = actions.latestJobByWorktree.get(worktreeName)
+  const runningAction = actions.isWorktreeBusy(worktreeName)
 
   useKeyboard(event => {
-    if (event.ctrl || event.meta || busy) return
+    if (event.ctrl || event.meta) return
 
     const maxIndex = Math.max(services.length - 1, 0)
 
@@ -186,25 +189,19 @@ export function WorktreeView({
       }
       case 'd':
         if (worktree) {
-          setBusy(true)
-          actions
-            .downWorktree(worktree.path, worktree.name)
-            .then(result => {
-              showStatus(result.message, result.success ? 'success' : 'error')
-            })
-            .finally(() => setBusy(false))
+          const result = actions.downWorktree(worktree.path, worktree.name)
+          if (!result.accepted) {
+            showStatus(result.message, 'error')
+          }
         }
         break
       case 'x': {
         const selected = services[selectedIndex]
         if (selected?.type === 'host' && selected.hostService) {
-          setBusy(true)
-          actions
-            .killHostService(selected.hostService)
-            .then(result => {
-              showStatus(result.message, result.success ? 'success' : 'error')
-            })
-            .finally(() => setBusy(false))
+          const result = actions.killHostService(selected.hostService)
+          if (!result.accepted) {
+            showStatus(result.message, 'error')
+          }
         }
         break
       }
@@ -219,7 +216,10 @@ export function WorktreeView({
           <b>{worktreeName}</b>
         </text>
         {loading && <text fg="#888888"> refreshing...</text>}
-        {busy && <text fg="#FFFF00"> working...</text>}
+        {runningAction && latestJob && <text fg="#FFFF00"> {latestJob.kind}...</text>}
+        {!runningAction && latestJob?.status === 'error' && (
+          <text fg="#FF4444"> {latestJob.kind} failed</text>
+        )}
       </box>
 
       {/* URL */}


### PR DESCRIPTION
## Summary
- Reworked TUI actions to run non-blocking per worktree with concurrency guards, live streamed command output, cancellation support, and graceful shutdown on exit (`q`/`Ctrl+C` with 5s drain + force-exit on second `Ctrl+C`).
- Replaced global action-log navigation with per-worktree output UX: row-level status badges, output title status timing (`running/finished/failed/cancelled`), per-worktree `[l]` show/hide behavior, auto-show on command start, auto-hide on completion, placeholder when hidden, and dashboard layout fixes to keep output bottom-aligned without clipping key hints.
## Testing
- Added/expanded tests for reducer/state transitions, enqueue rejection semantics, streaming exec/compose behavior, TUI view interactions, and graceful exit (`src/tui/hooks/useActions.state.test.ts`, `src/lib/execStreaming.test.ts`, `src/lib/compose.stream.test.ts`, `src/tui/__tests__/Dashboard.test.tsx`, `src/tui/__tests__/WorktreeView.test.tsx`, `src/tui/__tests__/App.exit.test.ts`).
- Verified with targeted and combined test runs plus typecheck (`bun test ...`, `bunx vitest run src/lib/compose.stream.test.ts`, `bun x tsc --noEmit`); tests passed with existing non-failing React `act(...)` warnings in TUI tests.
## Risks
- TUI output-follow behavior depends on scrollbox semantics and may vary slightly with terminal/window constraints despite added bottom-pin logic.
- Large behavioral surface area changed in one branch (actions, output UX, exit flow); mitigation: broad automated test coverage and incremental commits to ease review/cherry-pick.