### PR TITLE
Traefik 404 existence check

### DIFF
--- a/src/commands/run.ts
+++ b/src/commands/run.ts
@@ -91,7 +91,7 @@ export async function run(logicalPort: number, command: string[]): Promise<void>
 
   const configUpdated = await ensureTraefikPorts([logicalPort])
   if (configUpdated) {
-    output.info('Updated Traefik configuration with new port')
+    output.info('Updated Traefik configuration')
   }
 
   // Start or restart Traefik if needed

--- a/src/commands/up.ts
+++ b/src/commands/up.ts
@@ -86,7 +86,7 @@ export async function up(): Promise<void> {
   // Ensure all required ports are configured in Traefik
   const configUpdated = await ensureTraefikPorts(ports)
   if (configUpdated) {
-    output.info('Updated Traefik configuration with new ports')
+    output.info('Updated Traefik configuration')
   }
 
   // Ensure the 404 handler image is available (builds locally when running from source)

--- a/src/lib/traefik.test.ts
+++ b/src/lib/traefik.test.ts
@@ -1,6 +1,6 @@
 import { readFile, rm, writeFile } from 'fs/promises'
 import { existsSync } from 'fs'
-import { stringify as yamlStringify } from 'yaml'
+import { stringify as yamlStringify, parse as yamlParse } from 'yaml'
 import { describe, test, expect, beforeAll, beforeEach } from 'vitest'
 import { useIsolatedPortGlobalDir } from '@tests/isolatedGlobalDir'
 
@@ -197,5 +197,58 @@ describe('composeNeeds404HandlerUpdate', () => {
   test('returns false when service exists with current image', async () => {
     await traefik.initTraefikFiles([3000])
     expect(await traefik.composeNeeds404HandlerUpdate()).toBe(false)
+  })
+})
+
+describe('ensureTraefikPorts compose drift handling', () => {
+  useIsolatedPortGlobalDir('port-traefik-ports-drift-test', { resetModules: true })
+
+  beforeAll(async () => {
+    traefik = await import('./traefik.ts')
+  })
+
+  beforeEach(async () => {
+    await rm(traefik.TRAEFIK_DIR, { recursive: true, force: true })
+  })
+
+  test('rewrites compose when port-404-handler service is missing', async () => {
+    await traefik.initTraefikFiles([3000])
+
+    // Strip port-404-handler to simulate a pre-fa14450 compose file.
+    const before = await readFile(traefik.TRAEFIK_COMPOSE_FILE, 'utf-8')
+    const parsed = yamlParse(before) as { services: Record<string, unknown> }
+    delete parsed.services['port-404-handler']
+    await writeFile(traefik.TRAEFIK_COMPOSE_FILE, yamlStringify(parsed))
+
+    const updated = await traefik.ensureTraefikPorts([3000])
+    expect(updated).toBe(true)
+
+    const after = await readFile(traefik.TRAEFIK_COMPOSE_FILE, 'utf-8')
+    expect(after).toContain('port-404-handler')
+    expect(after).toContain('ghcr.io/jdtzmn/port-404-handler:')
+  })
+
+  test('rewrites compose when port-404-handler image is stale', async () => {
+    await traefik.initTraefikFiles([3000])
+
+    const content = await readFile(traefik.TRAEFIK_COMPOSE_FILE, 'utf-8')
+    const stale = content.replace(
+      /image: ghcr\.io\/jdtzmn\/port-404-handler:[^\s]+/,
+      'image: ghcr.io/jdtzmn/port-404-handler:0.0.0'
+    )
+    await writeFile(traefik.TRAEFIK_COMPOSE_FILE, stale)
+
+    const updated = await traefik.ensureTraefikPorts([3000])
+    expect(updated).toBe(true)
+
+    const after = await readFile(traefik.TRAEFIK_COMPOSE_FILE, 'utf-8')
+    expect(after).not.toContain('port-404-handler:0.0.0')
+  })
+
+  test('fast-path no-ops when everything matches', async () => {
+    await traefik.initTraefikFiles([3000])
+
+    const updated = await traefik.ensureTraefikPorts([3000])
+    expect(updated).toBe(false)
   })
 })

--- a/src/lib/traefik.test.ts
+++ b/src/lib/traefik.test.ts
@@ -1,5 +1,6 @@
-import { readFile, rm } from 'fs/promises'
+import { readFile, rm, writeFile } from 'fs/promises'
 import { existsSync } from 'fs'
+import { stringify as yamlStringify } from 'yaml'
 import { describe, test, expect, beforeAll, beforeEach } from 'vitest'
 import { useIsolatedPortGlobalDir } from '@tests/isolatedGlobalDir'
 
@@ -146,5 +147,55 @@ describe('Traefik 404 handler', () => {
     // The logic now lives in the Docker image, not in an inline shell command
     expect(composeContent).not.toContain('docker ps')
     expect(composeContent).not.toContain('socat')
+  })
+})
+
+describe('composeNeeds404HandlerUpdate', () => {
+  useIsolatedPortGlobalDir('port-traefik-404-drift-test', { resetModules: true })
+
+  beforeAll(async () => {
+    traefik = await import('./traefik.ts')
+  })
+
+  beforeEach(async () => {
+    await rm(traefik.TRAEFIK_DIR, { recursive: true, force: true })
+  })
+
+  test('returns true when compose file is missing', async () => {
+    expect(await traefik.composeNeeds404HandlerUpdate()).toBe(true)
+  })
+
+  test('returns true when compose file is unparseable', async () => {
+    await traefik.ensureTraefikDir()
+    await writeFile(traefik.TRAEFIK_COMPOSE_FILE, ': : not yaml :\n  -')
+    expect(await traefik.composeNeeds404HandlerUpdate()).toBe(true)
+  })
+
+  test('returns true when port-404-handler service is missing', async () => {
+    await traefik.ensureTraefikDir()
+    const stripped = yamlStringify({
+      services: {
+        traefik: { image: 'traefik:v3.6' },
+      },
+      networks: { 'traefik-network': { external: true } },
+    })
+    await writeFile(traefik.TRAEFIK_COMPOSE_FILE, stripped)
+    expect(await traefik.composeNeeds404HandlerUpdate()).toBe(true)
+  })
+
+  test('returns true when port-404-handler image does not match', async () => {
+    await traefik.initTraefikFiles([3000])
+    const content = await readFile(traefik.TRAEFIK_COMPOSE_FILE, 'utf-8')
+    const stale = content.replace(
+      /image: ghcr\.io\/jdtzmn\/port-404-handler:[^\s]+/,
+      'image: ghcr.io/jdtzmn/port-404-handler:0.0.0'
+    )
+    await writeFile(traefik.TRAEFIK_COMPOSE_FILE, stale)
+    expect(await traefik.composeNeeds404HandlerUpdate()).toBe(true)
+  })
+
+  test('returns false when service exists with current image', async () => {
+    await traefik.initTraefikFiles([3000])
+    expect(await traefik.composeNeeds404HandlerUpdate()).toBe(false)
   })
 })

--- a/src/lib/traefik.ts
+++ b/src/lib/traefik.ts
@@ -526,11 +526,17 @@ export async function ensureTraefikPorts(requiredPorts: number[]): Promise<boole
   const needsRestart = await withTraefikLock(async () => {
     const missingPorts = await getMissingPorts(requiredPorts)
     const needsFileProvider = !(await hasFileProvider())
+    const needs404HandlerUpdate = await composeNeeds404HandlerUpdate()
 
     // Fast path: nothing to change. Skip rewriting config + compose so that
     // concurrent `port up` invocations (e.g. parallel test workers) don't
     // serialize on the traefik lock for no-op work.
-    if (missingPorts.length === 0 && traefikFilesExist() && !needsFileProvider) {
+    if (
+      missingPorts.length === 0 &&
+      traefikFilesExist() &&
+      !needsFileProvider &&
+      !needs404HandlerUpdate
+    ) {
       return false
     }
 

--- a/src/lib/traefik.ts
+++ b/src/lib/traefik.ts
@@ -482,6 +482,40 @@ export async function ensureFileProvider(): Promise<boolean> {
 }
 
 /**
+ * Check whether the on-disk Traefik docker-compose.yml is missing the
+ * `port-404-handler` service, or has it pinned to an image other than the
+ * one we'd generate for this build of port.
+ *
+ * Returns `true` when the compose file needs to be rewritten so Traefik can
+ * actually serve the friendly 404 page. Returns `false` only when the service
+ * is present and pinned to the exact expected image string.
+ *
+ * Any read or YAML-parse failure is treated as "needs update" — better to
+ * regenerate a corrupt or unreadable file than to silently leave it broken.
+ */
+export async function composeNeeds404HandlerUpdate(): Promise<boolean> {
+  if (!existsSync(TRAEFIK_COMPOSE_FILE)) {
+    return true
+  }
+
+  let parsed: unknown
+  try {
+    const content = await readFile(TRAEFIK_COMPOSE_FILE, 'utf-8')
+    parsed = yamlParse(content)
+  } catch {
+    return true
+  }
+
+  const services = (parsed as { services?: Record<string, { image?: unknown }> } | null)?.services
+  const handler = services?.['port-404-handler']
+  if (!handler || typeof handler.image !== 'string') {
+    return true
+  }
+
+  return handler.image !== get404HandlerImage()
+}
+
+/**
  * Ensure Traefik is configured with all required ports
  * Updates config and compose if new ports are needed
  *


### PR DESCRIPTION
Cleanup following #75.

## Summary
- Fix `port up`/`port run` failing to add or update the `port-404-handler` service in `~/.port/traefik/docker-compose.yml`. The `ensureTraefikPorts` fast-path previously skipped rewriting compose when ports/file-provider were already current, leaving users on pre-existing setups without the 404 handler container (so unknown-host requests hit a non-existent backend).
- Add `composeNeeds404HandlerUpdate()` helper that detects a missing `port-404-handler` service or an image tag that doesn't exactly match `get404HandlerImage()`, and treat that as fast-path drift so the existing rewrite + restart flow runs.
- Generalize the user-facing log line in `up.ts` and `run.ts` from "Updated Traefik configuration with new port(s)" to "Updated Traefik configuration", since the trigger is no longer port-specific.
## Testing
- `bun vitest run src/lib/traefik.test.ts` — 18 passed (8 new: 5 covering the helper across missing/unparseable/missing-service/stale-image/current cases, plus 3 covering `ensureTraefikPorts` rewriting on missing service, rewriting on stale image, and the fast-path no-op).
- `bun vitest run src/commands/up.test.ts src/commands/up.command.test.ts src/commands/run.test.ts` — 16 passed, 1 skipped.
## Risks
- Users with a stale compose file will get a one-time Traefik restart on their next `port up`/`port run` (intended; that's how the new container is brought up). Parallel-worker fast-path optimization is preserved when there's no drift.
- Image-tag check is exact-match against `get404HandlerImage()`, so anyone running a custom registry/tag will see a one-time rewrite back to the canonical image. Not expected to affect normal users.

_(Drafted by Jacob's coding agent on his behalf)_