### PR TITLE
Grant packages: write to publish-docker caller

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -14,6 +14,9 @@ jobs:
   publish-docker:
     name: Publish Docker image
     needs: verify
+    permissions:
+      contents: read
+      packages: write
     uses: ./.github/workflows/publish-docker.yml
 
   publish:


### PR DESCRIPTION
The reusable publish-docker.yml workflow needs packages:write to push the 404-handler image to ghcr.io, but caller jobs cannot exceed the permissions granted by the calling job. Declare the required permissions on the publish-docker job in publish.yml so the release workflow validates.