### PR TITLE
Document onboard docker command

### DIFF
--- a/src/commands/__snapshots__/onboard.test.ts.snap
+++ b/src/commands/__snapshots__/onboard.test.ts.snap
@@ -66,6 +66,8 @@ Port is a CLI for managing git worktrees that makes it easy to create, enter, an
 
 ## Additional Commands
 
+- **\`port docker\`**: Alias: port compose. Automatically applies -f flags for the worktree's compose files.
+  - Run inside a worktree to run docker compose commands.
 - **\`port compose [args...]\`**: Automatically applies -f flags for the worktree's compose files.
   - Alias: port dc. Run inside a worktree to run docker compose commands.
 - **\`port completion <shell>\`**: Enables tab completion for port commands and options.
@@ -145,6 +147,8 @@ Port is a CLI for managing git worktrees that makes it easy to create, enter, an
 
 ## Additional Commands
 
+- **\`port docker\`**: Alias: port compose. Automatically applies -f flags for the worktree's compose files.
+  - Run inside a worktree to run docker compose commands.
 - **\`port compose [args...]\`**: Automatically applies -f flags for the worktree's compose files.
   - Alias: port dc. Run inside a worktree to run docker compose commands.
 - **\`port completion <shell>\`**: Enables tab completion for port commands and options.

--- a/src/commands/onboard.test.ts
+++ b/src/commands/onboard.test.ts
@@ -54,6 +54,7 @@ describe('onboard command', () => {
     expect(mocks.header).toHaveBeenCalledWith('3. port shell-hook <bash|zsh|fish>')
     expect(mocks.header).toHaveBeenCalledWith('4. port enter <branch>')
     expect(mocks.header).toHaveBeenCalledWith('6. port open')
+    expect(mocks.header).toHaveBeenCalledWith(expect.stringContaining('port docker'))
     expect(mocks.header).toHaveBeenCalledWith(expect.stringContaining('port compose'))
     expect(mocks.header).toHaveBeenCalledWith(expect.stringContaining('port completion'))
     expect(mocks.header).toHaveBeenCalledWith(expect.stringContaining('port exit'))

--- a/src/commands/onboard.ts
+++ b/src/commands/onboard.ts
@@ -69,6 +69,11 @@ const STEPS: OnboardStep[] = [
 
 const ADDITIONAL_COMMANDS: OnboardStep[] = [
   {
+    command: 'port docker',
+    how: 'Run inside a worktree to run docker compose commands.',
+    why: 'Alias: port compose. Automatically applies -f flags for the worktree\'s compose files.',
+  },
+  {
     command: 'port compose [args...]',
     how: 'Alias: port dc. Run inside a worktree to run docker compose commands.',
     why: "Automatically applies -f flags for the worktree's compose files.",


### PR DESCRIPTION
## Summary
- Add `port docker` to the onboarding guide as the docker-compose alias entry.
- Update onboarding tests and snapshots to cover the new command in generated output.
## Testing
- `bunx vitest run src/commands/onboard.test.ts`
- Passed
## Risks
- None noted
- Documentation-only change; low rollout risk