### PR TITLE
Add stale worktree warnings

### DIFF
--- a/README.md
+++ b/README.md
@@ -281,6 +281,14 @@ Shows archived branches created by `port remove` and asks for confirmation befor
 | `port uninstall [--yes] [--domain DOMAIN]`                          | Remove DNS configuration for wildcard domain                    |
 | `port hook [hook-name] [--list]`                                    | List or manually run a configured lifecycle hook                |
 
+### Stale Worktree Warnings
+
+`port status` and `port list` may warn when the repo has 10 or more stale Port worktrees:
+
+`You have X stale port worktrees. Consider running port prune.`
+
+`port enter <branch>` shows the same warning only when the stale count is extreme (25+), and it never blocks worktree creation.
+
 ## Hooks
 
 Port supports executable shell hooks in `.port/hooks/`:

--- a/bun.lock
+++ b/bun.lock
@@ -1,5 +1,6 @@
 {
   "lockfileVersion": 1,
+  "configVersion": 0,
   "workspaces": {
     "": {
       "name": "port",

--- a/src/commands/enter.command.test.ts
+++ b/src/commands/enter.command.test.ts
@@ -21,6 +21,9 @@ const mocks = vi.hoisted(() => ({
   spawn: vi.fn(),
   findSimilarCommand: vi.fn(),
   writeEvalFile: vi.fn(),
+  getStaleWorktreeCandidates: vi.fn(),
+  STALE_WORKTREE_EXTREME_THRESHOLD: 25,
+  formatStaleWorktreeWarning: vi.fn(),
   success: vi.fn(),
   warn: vi.fn(),
   error: vi.fn(),
@@ -76,6 +79,12 @@ vi.mock('../lib/commands.ts', () => ({
   findSimilarCommand: mocks.findSimilarCommand,
 }))
 
+vi.mock('../lib/staleWorktrees.ts', () => ({
+  getStaleWorktreeCandidates: mocks.getStaleWorktreeCandidates,
+  STALE_WORKTREE_EXTREME_THRESHOLD: mocks.STALE_WORKTREE_EXTREME_THRESHOLD,
+  formatStaleWorktreeWarning: mocks.formatStaleWorktreeWarning,
+}))
+
 vi.mock('../lib/output.ts', () => ({
   success: mocks.success,
   warn: mocks.warn,
@@ -124,6 +133,10 @@ describe('enter typo confirmation', () => {
     mocks.hookExists.mockResolvedValue(false)
     mocks.parseComposeFile.mockRejectedValue(new Error('compose missing'))
     mocks.getProjectName.mockReturnValue('repo-instal')
+    mocks.getStaleWorktreeCandidates.mockResolvedValue([])
+    mocks.formatStaleWorktreeWarning.mockImplementation(
+      (count: number) => `You have ${count} stale port worktrees. Consider running port prune.`
+    )
     mocks.branch.mockImplementation((value: string) => value)
     mocks.command.mockImplementation((value: string) => value)
 
@@ -222,6 +235,43 @@ describe('enter typo confirmation', () => {
 
     expect(mocks.prompt).not.toHaveBeenCalled()
     expect(mocks.createWorktree).toHaveBeenCalledWith('/repo', 'status')
+  })
+
+  test('warns when creating a new worktree and the stale count is extreme', async () => {
+    mocks.getStaleWorktreeCandidates.mockResolvedValue([
+      { branch: 'feature-a', sanitized: 'feature-a', reason: 'merged' },
+      { branch: 'feature-b', sanitized: 'feature-b', reason: 'gone' },
+      { branch: 'feature-c', sanitized: 'feature-c', reason: 'pr-merged' },
+      { branch: 'feature-d', sanitized: 'feature-d', reason: 'merged' },
+      { branch: 'feature-e', sanitized: 'feature-e', reason: 'gone' },
+      { branch: 'feature-f', sanitized: 'feature-f', reason: 'merged' },
+      { branch: 'feature-g', sanitized: 'feature-g', reason: 'merged' },
+      { branch: 'feature-h', sanitized: 'feature-h', reason: 'merged' },
+      { branch: 'feature-i', sanitized: 'feature-i', reason: 'merged' },
+      { branch: 'feature-j', sanitized: 'feature-j', reason: 'merged' },
+      { branch: 'feature-k', sanitized: 'feature-k', reason: 'merged' },
+      { branch: 'feature-l', sanitized: 'feature-l', reason: 'merged' },
+      { branch: 'feature-m', sanitized: 'feature-m', reason: 'merged' },
+      { branch: 'feature-n', sanitized: 'feature-n', reason: 'merged' },
+      { branch: 'feature-o', sanitized: 'feature-o', reason: 'merged' },
+      { branch: 'feature-p', sanitized: 'feature-p', reason: 'merged' },
+      { branch: 'feature-q', sanitized: 'feature-q', reason: 'merged' },
+      { branch: 'feature-r', sanitized: 'feature-r', reason: 'merged' },
+      { branch: 'feature-s', sanitized: 'feature-s', reason: 'merged' },
+      { branch: 'feature-t', sanitized: 'feature-t', reason: 'merged' },
+      { branch: 'feature-u', sanitized: 'feature-u', reason: 'merged' },
+      { branch: 'feature-v', sanitized: 'feature-v', reason: 'merged' },
+      { branch: 'feature-w', sanitized: 'feature-w', reason: 'merged' },
+      { branch: 'feature-x', sanitized: 'feature-x', reason: 'merged' },
+      { branch: 'feature-y', sanitized: 'feature-y', reason: 'merged' },
+    ])
+
+    await enter('new-feature')
+
+    expect(mocks.warn).toHaveBeenCalledWith(
+      'You have 25 stale port worktrees. Consider running port prune.'
+    )
+    expect(mocks.createWorktree).toHaveBeenCalledWith('/repo', 'new-feature')
   })
 })
 

--- a/src/commands/enter.ts
+++ b/src/commands/enter.ts
@@ -16,6 +16,11 @@ import inquirer from 'inquirer'
 import * as output from '../lib/output.ts'
 import { findSimilarCommand } from '../lib/commands.ts'
 import { buildEnterCommands, getEvalContext, writeEvalFile } from '../lib/shell.ts'
+import {
+  getStaleWorktreeCandidates,
+  STALE_WORKTREE_EXTREME_THRESHOLD,
+  formatStaleWorktreeWarning,
+} from '../lib/staleWorktrees.ts'
 
 /**
  * Enter a worktree (create if needed).
@@ -104,6 +109,15 @@ export async function enter(branch: string): Promise<void> {
           process.exit(1)
         }
       }
+    }
+
+    try {
+      const staleWorktrees = await getStaleWorktreeCandidates(repoRoot)
+      if (staleWorktrees.length >= STALE_WORKTREE_EXTREME_THRESHOLD) {
+        output.warn(formatStaleWorktreeWarning(staleWorktrees.length))
+      }
+    } catch {
+      // Opportunistic warning only; never block worktree creation.
     }
 
     output.info(`Creating worktree for branch: ${sanitized}`)

--- a/src/commands/list.test.ts
+++ b/src/commands/list.test.ts
@@ -5,6 +5,10 @@ const mocks = vi.hoisted(() => ({
   detectWorktree: vi.fn(),
   getTreesDir: vi.fn(),
   listWorktrees: vi.fn(),
+  getStaleWorktreeCandidates: vi.fn(),
+  STALE_WORKTREE_WARNING_THRESHOLD: 10,
+  formatStaleWorktreeWarning: vi.fn(),
+  warn: vi.fn(),
 }))
 
 vi.mock('../lib/worktree.ts', () => ({
@@ -17,6 +21,16 @@ vi.mock('../lib/config.ts', () => ({
 
 vi.mock('../lib/git.ts', () => ({
   listWorktrees: mocks.listWorktrees,
+}))
+
+vi.mock('../lib/staleWorktrees.ts', () => ({
+  getStaleWorktreeCandidates: mocks.getStaleWorktreeCandidates,
+  STALE_WORKTREE_WARNING_THRESHOLD: mocks.STALE_WORKTREE_WARNING_THRESHOLD,
+  formatStaleWorktreeWarning: mocks.formatStaleWorktreeWarning,
+}))
+
+vi.mock('../lib/output.ts', () => ({
+  warn: mocks.warn,
 }))
 
 vi.mock('fs', async importOriginal => {
@@ -36,6 +50,10 @@ describe('list command', () => {
     mocks.detectWorktree.mockReturnValue({ repoRoot: '/repo' })
     mocks.getTreesDir.mockReturnValue('/repo/.port/trees')
     mocks.listWorktrees.mockResolvedValue([])
+    mocks.getStaleWorktreeCandidates.mockResolvedValue([])
+    mocks.formatStaleWorktreeWarning.mockImplementation(
+      (count: number) => `You have ${count} stale port worktrees. Consider running port prune.`
+    )
   })
 
   test('prints worktree names one per line', async () => {
@@ -152,6 +170,63 @@ describe('list command', () => {
     expect(outputLines).toContain('jacob-test-sanitation')
     // Original name not available since git failed
     expect(outputLines).not.toContain('jacob/test/sanitation')
+    logSpy.mockRestore()
+  })
+
+  test('shows a stale worktree warning after listing names when the threshold is reached', async () => {
+    const logSpy = vi.spyOn(console, 'log').mockImplementation(() => undefined)
+    vi.mocked(existsSync).mockReturnValue(false)
+    mocks.getStaleWorktreeCandidates.mockResolvedValue([
+      { branch: 'feature-a', sanitized: 'feature-a', reason: 'merged' },
+      { branch: 'feature-b', sanitized: 'feature-b', reason: 'gone' },
+      { branch: 'feature-c', sanitized: 'feature-c', reason: 'pr-merged' },
+      { branch: 'feature-d', sanitized: 'feature-d', reason: 'merged' },
+      { branch: 'feature-e', sanitized: 'feature-e', reason: 'gone' },
+      { branch: 'feature-f', sanitized: 'feature-f', reason: 'merged' },
+      { branch: 'feature-g', sanitized: 'feature-g', reason: 'merged' },
+      { branch: 'feature-h', sanitized: 'feature-h', reason: 'merged' },
+      { branch: 'feature-i', sanitized: 'feature-i', reason: 'merged' },
+      { branch: 'feature-j', sanitized: 'feature-j', reason: 'merged' },
+    ])
+
+    await list()
+
+    expect(mocks.warn).toHaveBeenCalledWith(
+      'You have 10 stale port worktrees. Consider running port prune.'
+    )
+    logSpy.mockRestore()
+  })
+
+  test('does not show a stale worktree warning below the threshold', async () => {
+    const logSpy = vi.spyOn(console, 'log').mockImplementation(() => undefined)
+    vi.mocked(existsSync).mockReturnValue(false)
+    mocks.getStaleWorktreeCandidates.mockResolvedValue([
+      { branch: 'feature-a', sanitized: 'feature-a', reason: 'merged' },
+      { branch: 'feature-b', sanitized: 'feature-b', reason: 'gone' },
+      { branch: 'feature-c', sanitized: 'feature-c', reason: 'pr-merged' },
+      { branch: 'feature-d', sanitized: 'feature-d', reason: 'merged' },
+      { branch: 'feature-e', sanitized: 'feature-e', reason: 'gone' },
+      { branch: 'feature-f', sanitized: 'feature-f', reason: 'merged' },
+      { branch: 'feature-g', sanitized: 'feature-g', reason: 'merged' },
+      { branch: 'feature-h', sanitized: 'feature-h', reason: 'merged' },
+      { branch: 'feature-i', sanitized: 'feature-i', reason: 'merged' },
+    ])
+
+    await list()
+
+    expect(mocks.warn).not.toHaveBeenCalled()
+    logSpy.mockRestore()
+  })
+
+  test('continues listing names if stale worktree lookup fails', async () => {
+    const logSpy = vi.spyOn(console, 'log').mockImplementation(() => undefined)
+    vi.mocked(existsSync).mockReturnValue(false)
+    mocks.getStaleWorktreeCandidates.mockRejectedValue(new Error('lookup failed'))
+
+    await list()
+
+    expect(logSpy.mock.calls.map(call => call[0])).toEqual(['repo'])
+    expect(mocks.warn).not.toHaveBeenCalled()
     logSpy.mockRestore()
   })
 })

--- a/src/commands/list.ts
+++ b/src/commands/list.ts
@@ -3,6 +3,12 @@ import { detectWorktree } from '../lib/worktree.ts'
 import { getTreesDir } from '../lib/config.ts'
 import { sanitizeBranchName, sanitizeFolderName } from '../lib/sanitize.ts'
 import { listWorktrees } from '../lib/git.ts'
+import {
+  getStaleWorktreeCandidates,
+  STALE_WORKTREE_WARNING_THRESHOLD,
+  formatStaleWorktreeWarning,
+} from '../lib/staleWorktrees.ts'
+import * as output from '../lib/output.ts'
 
 /**
  * Get worktree names from the .port/trees/ directory without any expensive
@@ -85,6 +91,15 @@ export async function list(): Promise<void> {
     const names = await getWorktreeNamesWithOriginals(repoRoot)
     for (const name of names) {
       console.log(name)
+    }
+
+    try {
+      const staleWorktrees = await getStaleWorktreeCandidates(repoRoot)
+      if (staleWorktrees.length >= STALE_WORKTREE_WARNING_THRESHOLD) {
+        output.warn(formatStaleWorktreeWarning(staleWorktrees.length))
+      }
+    } catch {
+      // Opportunistic warning only; never block list output.
     }
   } catch {
     // Not in a git repo — output nothing

--- a/src/commands/prune.ts
+++ b/src/commands/prune.ts
@@ -1,19 +1,12 @@
 import inquirer from 'inquirer'
 import { detectWorktree } from '../lib/worktree.ts'
 import { loadConfigOrDefault, getComposeFile, ensurePortRuntimeDir } from '../lib/config.ts'
-import {
-  getDefaultBranch,
-  getMergedBranches,
-  getGoneBranches,
-  fetchAndPrune,
-  listWorktrees,
-} from '../lib/git.ts'
-import { isGhAvailable, getMergedPrBranches, type MergedPrInfo } from '../lib/github.ts'
+import { getDefaultBranch, fetchAndPrune } from '../lib/git.ts'
 import { removeWorktreeAndCleanup, stopWorktreeServices } from '../lib/removal.ts'
-import { sanitizeBranchName } from '../lib/sanitize.ts'
 import { failWithError } from '../lib/cli.ts'
 import { getProjectName } from '../lib/compose.ts'
 import { cleanupDockerResources, scanDockerResourcesForProject } from '../lib/docker-cleanup.ts'
+import { getStaleWorktreeCandidates, type StaleWorktreeCandidate } from '../lib/staleWorktrees.ts'
 import * as output from '../lib/output.ts'
 
 interface PruneOptions {
@@ -24,19 +17,7 @@ interface PruneOptions {
   cleanupImages?: boolean
 }
 
-/** Why a branch was identified as safe to remove */
-type PruneReason = 'merged' | 'gone' | 'pr-merged'
-
-interface PruneCandidate {
-  /** Original git branch name */
-  branch: string
-  /** Sanitized name (matches worktree directory) */
-  sanitized: string
-  /** Why this branch is considered safe to remove */
-  reason: PruneReason
-  /** PR metadata if detected via gh */
-  pr?: MergedPrInfo
-}
+type PruneCandidate = StaleWorktreeCandidate
 
 async function mapWithConcurrency<T, R>(
   items: T[],
@@ -131,71 +112,7 @@ export async function prune(options: PruneOptions = {}): Promise<void> {
 
   // 2. Determine the base branch
   const baseBranch = options.base ?? (await getDefaultBranch(repoRoot))
-
-  // 3. Get all worktrees managed by port (excluding main repo)
-  const worktrees = await listWorktrees(repoRoot)
-  const portWorktrees = worktrees.filter(wt => !wt.isMain)
-
-  if (portWorktrees.length === 0) {
-    output.info('No worktrees to prune.')
-    return
-  }
-
-  // Build a set of worktree branch names for fast lookup
-  const worktreeBranches = new Set(portWorktrees.map(wt => wt.branch))
-
-  // 4. Run detection strategies in parallel
-  const [mergedBranches, goneBranches, ghAvailable] = await Promise.all([
-    getMergedBranches(repoRoot, baseBranch),
-    getGoneBranches(repoRoot, { fetch: false }), // Already fetched above
-    isGhAvailable(),
-  ])
-
-  // Optionally fetch PR metadata
-  let prBranches = new Map<string, MergedPrInfo>()
-  if (ghAvailable) {
-    prBranches = await getMergedPrBranches(repoRoot)
-  }
-
-  // 5. Build candidates — only include branches that have worktrees
-  const candidateMap = new Map<string, PruneCandidate>()
-
-  for (const branch of mergedBranches) {
-    if (worktreeBranches.has(branch) && branch !== baseBranch) {
-      candidateMap.set(branch, {
-        branch,
-        sanitized: sanitizeBranchName(branch),
-        reason: 'merged',
-      })
-    }
-  }
-
-  for (const branch of goneBranches) {
-    if (worktreeBranches.has(branch) && !candidateMap.has(branch)) {
-      candidateMap.set(branch, {
-        branch,
-        sanitized: sanitizeBranchName(branch),
-        reason: 'gone',
-      })
-    }
-  }
-
-  // Check PR metadata for worktree branches not yet identified
-  for (const wt of portWorktrees) {
-    if (!candidateMap.has(wt.branch)) {
-      const prInfo = prBranches.get(wt.branch)
-      if (prInfo) {
-        candidateMap.set(wt.branch, {
-          branch: wt.branch,
-          sanitized: sanitizeBranchName(wt.branch),
-          reason: 'pr-merged',
-          pr: prInfo,
-        })
-      }
-    }
-  }
-
-  const candidates = Array.from(candidateMap.values())
+  const candidates = await getStaleWorktreeCandidates(repoRoot, { baseBranch })
 
   if (candidates.length === 0) {
     output.success('No merged worktrees found. Everything is clean.')

--- a/src/commands/status.test.ts
+++ b/src/commands/status.test.ts
@@ -10,12 +10,16 @@ const mocks = vi.hoisted(() => ({
   getAllHostServices: vi.fn(),
   isProcessRunning: vi.fn(),
   isTraefikRunning: vi.fn(),
+  getStaleWorktreeCandidates: vi.fn(),
+  STALE_WORKTREE_WARNING_THRESHOLD: 10,
+  formatStaleWorktreeWarning: vi.fn(),
   header: vi.fn(),
   newline: vi.fn(),
   branch: vi.fn(),
   success: vi.fn(),
   dim: vi.fn(),
   info: vi.fn(),
+  warn: vi.fn(),
   error: vi.fn(),
   url: vi.fn(),
 }))
@@ -47,6 +51,12 @@ vi.mock('../lib/compose.ts', () => ({
   isTraefikRunning: mocks.isTraefikRunning,
 }))
 
+vi.mock('../lib/staleWorktrees.ts', () => ({
+  getStaleWorktreeCandidates: mocks.getStaleWorktreeCandidates,
+  STALE_WORKTREE_WARNING_THRESHOLD: mocks.STALE_WORKTREE_WARNING_THRESHOLD,
+  formatStaleWorktreeWarning: mocks.formatStaleWorktreeWarning,
+}))
+
 vi.mock('../lib/output.ts', () => ({
   header: mocks.header,
   newline: mocks.newline,
@@ -54,6 +64,7 @@ vi.mock('../lib/output.ts', () => ({
   success: mocks.success,
   dim: mocks.dim,
   info: mocks.info,
+  warn: mocks.warn,
   error: mocks.error,
   url: mocks.url,
 }))
@@ -72,6 +83,10 @@ describe('status command', () => {
     mocks.getAllHostServices.mockResolvedValue([])
     mocks.isProcessRunning.mockReturnValue(true)
     mocks.isTraefikRunning.mockResolvedValue(false)
+    mocks.getStaleWorktreeCandidates.mockResolvedValue([])
+    mocks.formatStaleWorktreeWarning.mockImplementation(
+      (count: number) => `You have ${count} stale port worktrees. Consider running port prune.`
+    )
     mocks.branch.mockImplementation((value: string) => value)
     mocks.url.mockImplementation((value: string) => value)
   })
@@ -126,5 +141,57 @@ describe('status command', () => {
     expect(mocks.collectWorktreeStatuses).not.toHaveBeenCalled()
     expect(mocks.cleanupStaleHostServices).toHaveBeenCalledTimes(1)
     expect(mocks.error).not.toHaveBeenCalled()
+  })
+
+  test('shows a stale worktree warning when prune candidates cross the threshold', async () => {
+    mocks.getStaleWorktreeCandidates.mockResolvedValue([
+      { branch: 'feature-a', sanitized: 'feature-a', reason: 'merged' },
+      { branch: 'feature-b', sanitized: 'feature-b', reason: 'gone' },
+      { branch: 'feature-c', sanitized: 'feature-c', reason: 'pr-merged' },
+      { branch: 'feature-d', sanitized: 'feature-d', reason: 'merged' },
+      { branch: 'feature-e', sanitized: 'feature-e', reason: 'gone' },
+      { branch: 'feature-f', sanitized: 'feature-f', reason: 'merged' },
+      { branch: 'feature-g', sanitized: 'feature-g', reason: 'merged' },
+      { branch: 'feature-h', sanitized: 'feature-h', reason: 'merged' },
+      { branch: 'feature-i', sanitized: 'feature-i', reason: 'merged' },
+      { branch: 'feature-j', sanitized: 'feature-j', reason: 'merged' },
+    ])
+
+    await status()
+
+    expect(mocks.warn).toHaveBeenCalledWith(
+      'You have 10 stale port worktrees. Consider running port prune.'
+    )
+  })
+
+  test('does not show a stale worktree warning below the threshold', async () => {
+    mocks.getStaleWorktreeCandidates.mockResolvedValue([
+      { branch: 'feature-a', sanitized: 'feature-a', reason: 'merged' },
+      { branch: 'feature-b', sanitized: 'feature-b', reason: 'gone' },
+      { branch: 'feature-c', sanitized: 'feature-c', reason: 'pr-merged' },
+      { branch: 'feature-d', sanitized: 'feature-d', reason: 'merged' },
+      { branch: 'feature-e', sanitized: 'feature-e', reason: 'gone' },
+      { branch: 'feature-f', sanitized: 'feature-f', reason: 'merged' },
+      { branch: 'feature-g', sanitized: 'feature-g', reason: 'merged' },
+      { branch: 'feature-h', sanitized: 'feature-h', reason: 'merged' },
+      { branch: 'feature-i', sanitized: 'feature-i', reason: 'merged' },
+    ])
+
+    await status()
+
+    expect(mocks.warn).not.toHaveBeenCalledWith(
+      'You have 9 stale port worktrees. Consider running port prune.'
+    )
+  })
+
+  test('keeps status output when stale worktree lookup fails', async () => {
+    mocks.getStaleWorktreeCandidates.mockRejectedValue(new Error('lookup failed'))
+
+    await status()
+
+    expect(mocks.header).toHaveBeenCalledWith('Worktree service status:')
+    expect(mocks.warn).not.toHaveBeenCalledWith(
+      'You have 0 stale port worktrees. Consider running port prune.'
+    )
   })
 })

--- a/src/commands/status.ts
+++ b/src/commands/status.ts
@@ -4,6 +4,11 @@ import { isTraefikRunning } from '../lib/compose.ts'
 import { getAllHostServices } from '../lib/registry.ts'
 import { isProcessRunning, cleanupStaleHostServices } from '../lib/hostService.ts'
 import { collectWorktreeStatuses, type WorktreeStatus } from '../lib/worktreeStatus.ts'
+import {
+  getStaleWorktreeCandidates,
+  STALE_WORKTREE_WARNING_THRESHOLD,
+  formatStaleWorktreeWarning,
+} from '../lib/staleWorktrees.ts'
 import * as output from '../lib/output.ts'
 
 /**
@@ -13,9 +18,10 @@ import * as output from '../lib/output.ts'
  */
 export async function status(): Promise<void> {
   let worktrees: WorktreeStatus[] = []
+  let repoRoot: string | undefined
 
   try {
-    const repoRoot = detectWorktree().repoRoot
+    repoRoot = detectWorktree().repoRoot
 
     if (configExists(repoRoot)) {
       const config = await loadConfig(repoRoot)
@@ -70,5 +76,16 @@ export async function status(): Promise<void> {
     output.success(`Traefik: running (dashboard: ${output.url('http://localhost:1211')})`)
   } else {
     output.dim('Traefik: not running')
+  }
+
+  if (repoRoot && configExists(repoRoot)) {
+    try {
+      const staleWorktrees = await getStaleWorktreeCandidates(repoRoot)
+      if (staleWorktrees.length >= STALE_WORKTREE_WARNING_THRESHOLD) {
+        output.warn(formatStaleWorktreeWarning(staleWorktrees.length))
+      }
+    } catch {
+      // Opportunistic warning only; never block status output.
+    }
   }
 }

--- a/src/lib/staleWorktrees.test.ts
+++ b/src/lib/staleWorktrees.test.ts
@@ -1,0 +1,95 @@
+import { beforeEach, describe, expect, test, vi } from 'vitest'
+
+const mocks = vi.hoisted(() => ({
+  getDefaultBranch: vi.fn(),
+  getMergedBranches: vi.fn(),
+  getGoneBranches: vi.fn(),
+  listWorktrees: vi.fn(),
+  isGhAvailable: vi.fn(),
+  getMergedPrBranches: vi.fn(),
+}))
+
+vi.mock('./git.ts', () => ({
+  getDefaultBranch: mocks.getDefaultBranch,
+  getMergedBranches: mocks.getMergedBranches,
+  getGoneBranches: mocks.getGoneBranches,
+  listWorktrees: mocks.listWorktrees,
+}))
+
+vi.mock('./github.ts', () => ({
+  isGhAvailable: mocks.isGhAvailable,
+  getMergedPrBranches: mocks.getMergedPrBranches,
+}))
+
+import { getStaleWorktreeCandidates } from './staleWorktrees.ts'
+
+describe('getStaleWorktreeCandidates', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+
+    mocks.getDefaultBranch.mockResolvedValue('main')
+    mocks.getMergedBranches.mockResolvedValue([])
+    mocks.getGoneBranches.mockResolvedValue([])
+    mocks.listWorktrees.mockResolvedValue([
+      { path: '/repo', branch: 'main', isMain: true },
+      { path: '/repo/.port/trees/feature-a', branch: 'feature-a', isMain: false },
+      { path: '/repo/.port/trees/feature-b', branch: 'feature-b', isMain: false },
+      { path: '/repo/.port/trees/feature-c', branch: 'feature-c', isMain: false },
+    ])
+    mocks.isGhAvailable.mockResolvedValue(true)
+    mocks.getMergedPrBranches.mockResolvedValue(new Map())
+  })
+
+  test('returns merged, gone, and merged PR worktrees that exist locally', async () => {
+    mocks.getMergedBranches.mockResolvedValue(['feature-a'])
+    mocks.getGoneBranches.mockResolvedValue(['feature-b'])
+    mocks.getMergedPrBranches.mockResolvedValue(
+      new Map([
+        [
+          'feature-c',
+          {
+            number: 42,
+            headRefName: 'feature-c',
+            mergedAt: '2026-01-01T00:00:00Z',
+          },
+        ],
+      ])
+    )
+
+    const candidates = await getStaleWorktreeCandidates('/repo')
+
+    expect(candidates.map(candidate => candidate.branch)).toEqual([
+      'feature-a',
+      'feature-b',
+      'feature-c',
+    ])
+    expect(candidates).toHaveLength(3)
+  })
+
+  test('ignores stale branches that do not have Port worktrees', async () => {
+    mocks.getMergedBranches.mockResolvedValue(['feature-a', 'missing-branch'])
+
+    const candidates = await getStaleWorktreeCandidates('/repo')
+
+    expect(candidates.map(candidate => candidate.branch)).toEqual(['feature-a'])
+  })
+
+  test('deduplicates a branch reported by multiple detection paths', async () => {
+    mocks.getMergedBranches.mockResolvedValue(['feature-a'])
+    mocks.getGoneBranches.mockResolvedValue(['feature-a'])
+
+    const candidates = await getStaleWorktreeCandidates('/repo')
+
+    expect(candidates.map(candidate => candidate.branch)).toEqual(['feature-a'])
+  })
+
+  test('returns git-based candidates when gh is unavailable', async () => {
+    mocks.getMergedBranches.mockResolvedValue(['feature-a'])
+    mocks.isGhAvailable.mockResolvedValue(false)
+
+    const candidates = await getStaleWorktreeCandidates('/repo')
+
+    expect(candidates.map(candidate => candidate.branch)).toEqual(['feature-a'])
+    expect(mocks.getMergedPrBranches).not.toHaveBeenCalled()
+  })
+})

--- a/src/lib/staleWorktrees.ts
+++ b/src/lib/staleWorktrees.ts
@@ -1,0 +1,83 @@
+import { getDefaultBranch, getGoneBranches, getMergedBranches, listWorktrees } from './git.ts'
+import { getMergedPrBranches, isGhAvailable, type MergedPrInfo } from './github.ts'
+import { sanitizeBranchName } from './sanitize.ts'
+
+export const STALE_WORKTREE_WARNING_THRESHOLD = 10
+export const STALE_WORKTREE_EXTREME_THRESHOLD = 25
+
+export type StaleWorktreeReason = 'merged' | 'gone' | 'pr-merged'
+
+export interface StaleWorktreeCandidate {
+  branch: string
+  sanitized: string
+  reason: StaleWorktreeReason
+  pr?: MergedPrInfo
+}
+
+export function formatStaleWorktreeWarning(count: number): string {
+  return `You have ${count} stale port worktrees. Consider running port prune.`
+}
+
+export async function getStaleWorktreeCandidates(
+  repoRoot: string,
+  options: { baseBranch?: string } = {}
+): Promise<StaleWorktreeCandidate[]> {
+  try {
+    const baseBranch = options.baseBranch ?? (await getDefaultBranch(repoRoot))
+    const worktrees = await listWorktrees(repoRoot)
+    const worktreeBranches = new Set(worktrees.filter(wt => !wt.isMain).map(wt => wt.branch))
+
+    const [mergedBranches, goneBranches, ghAvailable] = await Promise.all([
+      getMergedBranches(repoRoot, baseBranch),
+      getGoneBranches(repoRoot, { fetch: false }),
+      isGhAvailable(),
+    ])
+
+    let prBranches = new Map<string, MergedPrInfo>()
+    if (ghAvailable) {
+      prBranches = await getMergedPrBranches(repoRoot)
+    }
+
+    const candidateMap = new Map<string, StaleWorktreeCandidate>()
+
+    for (const branch of mergedBranches) {
+      if (worktreeBranches.has(branch) && branch !== baseBranch) {
+        candidateMap.set(branch, {
+          branch,
+          sanitized: sanitizeBranchName(branch),
+          reason: 'merged',
+        })
+      }
+    }
+
+    for (const branch of goneBranches) {
+      if (worktreeBranches.has(branch) && !candidateMap.has(branch)) {
+        candidateMap.set(branch, {
+          branch,
+          sanitized: sanitizeBranchName(branch),
+          reason: 'gone',
+        })
+      }
+    }
+
+    for (const branch of worktreeBranches) {
+      if (candidateMap.has(branch)) {
+        continue
+      }
+
+      const prInfo = prBranches.get(branch)
+      if (prInfo) {
+        candidateMap.set(branch, {
+          branch,
+          sanitized: sanitizeBranchName(branch),
+          reason: 'pr-merged',
+          pr: prInfo,
+        })
+      }
+    }
+
+    return Array.from(candidateMap.values())
+  } catch {
+    return []
+  }
+}


### PR DESCRIPTION
## Summary
- Added passive stale-worktree warnings to `port status` and `port list`, with a stronger non-blocking warning on `port enter` when the stale count is extreme.
- Extracted shared stale-worktree candidate detection so `prune`, `status`, `list`, and `enter` use the same definition of stale Port worktrees.
- Documented the warning behavior in the README and added coverage for the new warning surfaces.
## Testing
- `bunx vitest run src/lib/staleWorktrees.test.ts src/commands/status.test.ts src/commands/list.test.ts src/commands/enter.command.test.ts src/commands/prune.test.ts`
- `bun run typecheck`
- `bun run format:check`
- Result: targeted tests, typecheck, and formatting passed; full Vitest suite still hit existing Docker-dependent integration failures in this environment.
## Risks
- Docker-backed integration tests are not passing in this environment, so the change is verified primarily through targeted unit tests.
- The warning is intentionally opportunistic and non-blocking, so users may not see it if stale-candidate lookup fails.