### PR TITLE
Start Traefik before `port compose` command

### DIFF
--- a/src/commands/compose.test.ts
+++ b/src/commands/compose.test.ts
@@ -65,6 +65,8 @@ describe('port compose pre-sync behavior', () => {
     )
     vi.spyOn(composeModule, 'writeOverrideFile').mockResolvedValue()
     vi.spyOn(composeModule, 'getProjectName').mockReturnValue('repo-feature-1')
+    vi.spyOn(composeModule, 'isTraefikRunning').mockResolvedValue(true)
+    vi.spyOn(composeModule, 'startTraefik').mockResolvedValue()
     vi.spyOn(composeModule, 'runCompose').mockResolvedValue({ exitCode: 0 } as unknown as Awaited<
       ReturnType<typeof composeModule.runCompose>
     >)
@@ -194,6 +196,24 @@ describe('port compose pre-sync behavior', () => {
           domain: mockConfig.domain,
         }
       )
+    })
+
+    test('starts Traefik first when it is not running', async () => {
+      const isTraefikRunningSpy = vi.spyOn(composeModule, 'isTraefikRunning').mockResolvedValue(false)
+      const startTraefikSpy = vi.spyOn(composeModule, 'startTraefik').mockResolvedValue()
+      const runComposeSpy = vi.spyOn(composeModule, 'runCompose')
+      const infoSpy = vi.spyOn(output, 'info').mockImplementation(() => {})
+
+      try {
+        await compose(['up', '-d'])
+      } catch (error) {
+        // Expected - process.exit throws in our mock
+      }
+
+      expect(isTraefikRunningSpy).toHaveBeenCalled()
+      expect(startTraefikSpy).toHaveBeenCalled()
+      expect(infoSpy).toHaveBeenCalledWith('Starting Traefik...')
+      expect(runComposeSpy).toHaveBeenCalled()
     })
 
     test('exits with docker compose exit code on success', async () => {

--- a/src/commands/compose.test.ts
+++ b/src/commands/compose.test.ts
@@ -199,7 +199,9 @@ describe('port compose pre-sync behavior', () => {
     })
 
     test('starts Traefik first when it is not running', async () => {
-      const isTraefikRunningSpy = vi.spyOn(composeModule, 'isTraefikRunning').mockResolvedValue(false)
+      const isTraefikRunningSpy = vi
+        .spyOn(composeModule, 'isTraefikRunning')
+        .mockResolvedValue(false)
       const startTraefikSpy = vi.spyOn(composeModule, 'startTraefik').mockResolvedValue()
       const runComposeSpy = vi.spyOn(composeModule, 'runCompose')
       const infoSpy = vi.spyOn(output, 'info').mockImplementation(() => {})

--- a/src/commands/compose.test.ts
+++ b/src/commands/compose.test.ts
@@ -3,6 +3,7 @@ import { compose } from './compose.ts'
 import * as worktreeModule from '../lib/worktree.ts'
 import * as configModule from '../lib/config.ts'
 import * as composeModule from '../lib/compose.ts'
+import * as traefikModule from '../lib/traefik.ts'
 import * as output from '../lib/output.ts'
 
 /**
@@ -65,6 +66,7 @@ describe('port compose pre-sync behavior', () => {
     )
     vi.spyOn(composeModule, 'writeOverrideFile').mockResolvedValue()
     vi.spyOn(composeModule, 'getProjectName').mockReturnValue('repo-feature-1')
+    vi.spyOn(traefikModule, 'ensureTraefikPorts').mockResolvedValue(true)
     vi.spyOn(composeModule, 'isTraefikRunning').mockResolvedValue(true)
     vi.spyOn(composeModule, 'startTraefik').mockResolvedValue()
     vi.spyOn(composeModule, 'runCompose').mockResolvedValue({ exitCode: 0 } as unknown as Awaited<
@@ -202,6 +204,9 @@ describe('port compose pre-sync behavior', () => {
       const isTraefikRunningSpy = vi
         .spyOn(composeModule, 'isTraefikRunning')
         .mockResolvedValue(false)
+      const ensureTraefikPortsSpy = vi
+        .spyOn(traefikModule, 'ensureTraefikPorts')
+        .mockResolvedValue(true)
       const startTraefikSpy = vi.spyOn(composeModule, 'startTraefik').mockResolvedValue()
       const runComposeSpy = vi.spyOn(composeModule, 'runCompose')
       const infoSpy = vi.spyOn(output, 'info').mockImplementation(() => {})
@@ -213,6 +218,7 @@ describe('port compose pre-sync behavior', () => {
       }
 
       expect(isTraefikRunningSpy).toHaveBeenCalled()
+      expect(ensureTraefikPortsSpy).toHaveBeenCalledWith([3000])
       expect(startTraefikSpy).toHaveBeenCalled()
       expect(infoSpy).toHaveBeenCalledWith('Starting Traefik...')
       expect(runComposeSpy).toHaveBeenCalled()

--- a/src/commands/compose.ts
+++ b/src/commands/compose.ts
@@ -2,7 +2,7 @@ import { existsSync } from 'fs'
 import { join } from 'path'
 import { detectWorktree } from '../lib/worktree.ts'
 import { loadConfigOrDefault, getComposeFile, ensurePortRuntimeDir } from '../lib/config.ts'
-import { runCompose, getProjectName, parseComposeFile, writeOverrideFile } from '../lib/compose.ts'
+import * as composeLib from '../lib/compose.ts'
 import * as output from '../lib/output.ts'
 
 /**
@@ -50,23 +50,33 @@ export async function compose(args: string[]): Promise<void> {
   // Synchronize override file before execution (fail-closed)
   let parsedCompose
   try {
-    parsedCompose = await parseComposeFile(worktreePath, composeFile)
+    parsedCompose = await composeLib.parseComposeFile(worktreePath, composeFile)
   } catch (error) {
     output.error(`Failed to parse compose file: ${error}`)
     process.exit(1)
   }
 
-  const projectName = getProjectName(repoRoot, name)
+  const projectName = composeLib.getProjectName(repoRoot, name)
 
   try {
-    await writeOverrideFile(worktreePath, parsedCompose, name, config.domain, projectName)
+    await composeLib.writeOverrideFile(worktreePath, parsedCompose, name, config.domain, projectName)
   } catch (error) {
     output.error(`Failed to write override file: ${error}`)
     process.exit(1)
   }
 
+  try {
+    if (!(await composeLib.isTraefikRunning())) {
+      output.info('Starting Traefik...')
+      await composeLib.startTraefik()
+    }
+  } catch (error) {
+    output.error(`Failed to start Traefik: ${error}`)
+    process.exit(1)
+  }
+
   // Run the compose command with automatic -p and -f flags
-  const { exitCode } = await runCompose(worktreePath, composeFile, projectName, args, {
+  const { exitCode } = await composeLib.runCompose(worktreePath, composeFile, projectName, args, {
     repoRoot,
     branch: name,
     domain: config.domain,

--- a/src/commands/compose.ts
+++ b/src/commands/compose.ts
@@ -3,6 +3,7 @@ import { join } from 'path'
 import { detectWorktree } from '../lib/worktree.ts'
 import { loadConfigOrDefault, getComposeFile, ensurePortRuntimeDir } from '../lib/config.ts'
 import * as composeLib from '../lib/compose.ts'
+import * as traefikLib from '../lib/traefik.ts'
 import * as output from '../lib/output.ts'
 
 /**
@@ -73,6 +74,7 @@ export async function compose(args: string[]): Promise<void> {
 
   try {
     if (!(await composeLib.isTraefikRunning())) {
+      await traefikLib.ensureTraefikPorts(composeLib.getAllPorts(parsedCompose))
       output.info('Starting Traefik...')
       await composeLib.startTraefik()
     }

--- a/src/commands/compose.ts
+++ b/src/commands/compose.ts
@@ -59,7 +59,13 @@ export async function compose(args: string[]): Promise<void> {
   const projectName = composeLib.getProjectName(repoRoot, name)
 
   try {
-    await composeLib.writeOverrideFile(worktreePath, parsedCompose, name, config.domain, projectName)
+    await composeLib.writeOverrideFile(
+      worktreePath,
+      parsedCompose,
+      name,
+      config.domain,
+      projectName
+    )
   } catch (error) {
     output.error(`Failed to write override file: ${error}`)
     process.exit(1)

--- a/tests/compose-e2e.test.ts
+++ b/tests/compose-e2e.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, test } from 'vitest'
+import { execAsync } from '../src/lib/exec'
+import { execPortAsync, prepareSample, safeDown } from './utils'
+
+const TIMEOUT = 120000
+
+async function waitForTraefikRunning(maxWaitMs = 30000): Promise<void> {
+  const startTime = Date.now()
+
+  while (Date.now() - startTime < maxWaitMs) {
+    const { stdout } = await execAsync('docker ps --filter name=port-traefik --format "{{.Names}}"')
+    if (stdout.trim() === 'port-traefik') {
+      return
+    }
+
+    await new Promise(resolve => setTimeout(resolve, 500))
+  }
+
+  throw new Error('Timed out waiting for Traefik to start')
+}
+
+async function hasDockerDaemon(): Promise<boolean> {
+  try {
+    await execAsync('docker info >/dev/null 2>&1')
+    return true
+  } catch {
+    return false
+  }
+}
+
+describe.sequential('port compose e2e', () => {
+  test(
+    'starts Traefik and prints a notice when it is down',
+    async () => {
+      if (!(await hasDockerDaemon())) {
+        return
+      }
+
+      const sample = await prepareSample('db-and-server', { initWithConfig: true })
+
+      try {
+        await execAsync('docker rm -f port-traefik 2>/dev/null || true')
+
+        const result = await execPortAsync(['compose', 'up', '-d'], sample.dir)
+
+        expect(result.stderr).toContain('Starting Traefik...')
+
+        await waitForTraefikRunning()
+
+        const { stdout } = await execAsync(
+          'docker ps --filter name=port-traefik --format "{{.Names}}"'
+        )
+        expect(stdout.trim()).toBe('port-traefik')
+      } finally {
+        await safeDown(sample.dir)
+        await sample.cleanup()
+      }
+    },
+    TIMEOUT
+  )
+})


### PR DESCRIPTION
## Summary
- Auto-start Traefik when `port compose`/`port dc` is run and Traefik is not already running.
- Keep override-file sync in place so Port-managed compose runs stay routing-ready.

## Testing
- `bunx vitest src/commands/compose.test.ts`
- `bunx tsc --noEmit`
- `bunx eslint src/commands/compose.ts src/commands/compose.test.ts`

## Risks
- Traefik startup now adds a small delay to compose commands when the proxy is stopped.
- If Traefik fails to start, `port dc` now exits early instead of continuing with unrouted containers.

_(Drafted by Jacob's coding agent on his behalf)_