### PR TITLE
Batch macOS DNS setup into one sudo call

### DIFF
--- a/src/commands/install.test.ts
+++ b/src/commands/install.test.ts
@@ -162,12 +162,13 @@ describe('install command domain handling', () => {
 
     await install({ yes: true, domain: 'stlabs' })
 
-    expect(mocks.execAsync).toHaveBeenCalledWith(
-      'echo "address=/stlabs/127.0.0.1" >> /opt/homebrew/etc/dnsmasq.conf'
-    )
     expect(mocks.execPrivileged).toHaveBeenCalledWith(
-      '/opt/homebrew/bin/brew services restart dnsmasq'
+      expect.stringContaining(
+        'mkdir -p /etc/resolver && echo "nameserver 127.0.0.1" > \'/etc/resolver/stlabs\' && /opt/homebrew/bin/brew services restart dnsmasq'
+      )
     )
+    expect(mocks.execPrivileged).toHaveBeenCalledTimes(1)
+    expect(mocks.success).toHaveBeenCalledWith('Resolver configured at /etc/resolver/stlabs')
     expect(mocks.success).toHaveBeenCalledWith('dnsmasq service reloaded')
   })
 
@@ -201,12 +202,16 @@ describe('install command domain handling', () => {
     await install({ yes: true, domain: 'stlabs' })
 
     expect(mocks.execPrivileged).toHaveBeenCalledWith(
-      '/opt/homebrew/bin/brew services restart dnsmasq'
+      expect.stringContaining(
+        'mkdir -p /etc/resolver && echo "nameserver 127.0.0.1" > \'/etc/resolver/stlabs\' && /opt/homebrew/bin/brew services restart dnsmasq'
+      )
     )
+    expect(mocks.execPrivileged).toHaveBeenCalledTimes(1)
+    expect(mocks.success).toHaveBeenCalledWith('Resolver configured at /etc/resolver/stlabs')
     expect(mocks.success).toHaveBeenCalledWith('dnsmasq service reloaded')
   })
 
-  test('creates resolver even when dnsmasq service restart fails (non-admin user)', async () => {
+  test('fails when dnsmasq restart path errors (non-admin user)', async () => {
     mocks.checkDns.mockResolvedValue(false)
 
     mocks.execAsync.mockImplementation(async (cmd: string) => {
@@ -230,15 +235,7 @@ describe('install command domain handling', () => {
     })
 
     mocks.execPrivileged.mockImplementation(async (cmd: string) => {
-      if (cmd === 'mkdir -p /etc/resolver') {
-        return { stdout: '' }
-      }
-
-      if (cmd === 'echo "nameserver 127.0.0.1" > /etc/resolver/stlabs') {
-        return { stdout: '' }
-      }
-
-      if (cmd === '/opt/homebrew/bin/brew services restart dnsmasq') {
+      if (cmd.includes('restart dnsmasq')) {
         throw new Error('permission denied')
       }
 
@@ -247,21 +244,19 @@ describe('install command domain handling', () => {
 
     await install({ yes: true, domain: 'stlabs' })
 
-    // Resolver was still created despite service failure
-    expect(mocks.execPrivileged).toHaveBeenCalledWith('mkdir -p /etc/resolver')
     expect(mocks.execPrivileged).toHaveBeenCalledWith(
-      'echo "nameserver 127.0.0.1" > /etc/resolver/stlabs'
+      expect.stringContaining(
+        'mkdir -p /etc/resolver && echo "nameserver 127.0.0.1" > \'/etc/resolver/stlabs\' && /opt/homebrew/bin/brew services restart dnsmasq'
+      )
     )
-    expect(mocks.success).toHaveBeenCalledWith('Resolver created at /etc/resolver/stlabs')
-    // Service failure is reported
-    expect(mocks.info).toHaveBeenCalledWith('Run this command as an admin user:')
-    expect(mocks.info).toHaveBeenCalledWith(
-      '  sudo /opt/homebrew/bin/brew services restart dnsmasq'
+    expect(mocks.execPrivileged).toHaveBeenCalledTimes(1)
+    expect(mocks.error).toHaveBeenCalledWith(
+      expect.stringContaining('Failed to configure macOS DNS:')
     )
     expect(mocks.warn).toHaveBeenCalledWith('DNS setup incomplete')
   })
 
-  test('still attempts service restart when resolver creation fails', async () => {
+  test('fails when dnsmasq start path errors', async () => {
     mocks.checkDns.mockResolvedValue(false)
 
     mocks.execAsync.mockImplementation(async (cmd: string) => {
@@ -278,19 +273,15 @@ describe('install command domain handling', () => {
       }
 
       if (cmd === 'pgrep dnsmasq') {
-        return { stdout: '123\n' }
+        throw new Error('not running')
       }
 
       return { stdout: '' }
     })
 
     mocks.execPrivileged.mockImplementation(async (cmd: string) => {
-      if (cmd === 'mkdir -p /etc/resolver') {
+      if (cmd.includes('start dnsmasq')) {
         throw new Error('permission denied')
-      }
-
-      if (cmd === '/opt/homebrew/bin/brew services restart dnsmasq') {
-        return { stdout: '' }
       }
 
       return { stdout: '' }
@@ -298,12 +289,15 @@ describe('install command domain handling', () => {
 
     await install({ yes: true, domain: 'stlabs' })
 
-    // Service restart was still attempted despite resolver failure
     expect(mocks.execPrivileged).toHaveBeenCalledWith(
-      '/opt/homebrew/bin/brew services restart dnsmasq'
+      expect.stringContaining(
+        'mkdir -p /etc/resolver && echo "nameserver 127.0.0.1" > \'/etc/resolver/stlabs\' && /opt/homebrew/bin/brew services start dnsmasq'
+      )
     )
-    expect(mocks.success).toHaveBeenCalledWith('dnsmasq service reloaded')
-    // But overall result is incomplete
+    expect(mocks.execPrivileged).toHaveBeenCalledTimes(1)
+    expect(mocks.error).toHaveBeenCalledWith(
+      expect.stringContaining('Failed to configure macOS DNS:')
+    )
     expect(mocks.warn).toHaveBeenCalledWith('DNS setup incomplete')
   })
 
@@ -337,8 +331,12 @@ describe('install command domain handling', () => {
     await install({ yes: true, domain: 'stlabs' })
 
     expect(mocks.execPrivileged).toHaveBeenCalledWith(
-      '/opt/homebrew/bin/brew services start dnsmasq'
+      expect.stringContaining(
+        'mkdir -p /etc/resolver && echo "nameserver 127.0.0.1" > \'/etc/resolver/stlabs\' && /opt/homebrew/bin/brew services start dnsmasq'
+      )
     )
+    expect(mocks.execPrivileged).toHaveBeenCalledTimes(1)
+    expect(mocks.success).toHaveBeenCalledWith('Resolver configured at /etc/resolver/stlabs')
     expect(mocks.success).toHaveBeenCalledWith('dnsmasq service started')
   })
 })

--- a/src/commands/install.ts
+++ b/src/commands/install.ts
@@ -43,6 +43,26 @@ function normalizeDomain(domain: string): string {
   return domain.trim().toLowerCase()
 }
 
+function shellQuote(value: string): string {
+  return `'${value.replace(/'/g, `'"'"'`)}'`
+}
+
+function buildMacOSPrivilegedCommand(options: {
+  brewPrefix: string
+  dnsIp: string
+  domain: string
+  dnsmasqRunning: boolean
+}): string {
+  const resolverPath = shellQuote(`/etc/resolver/${options.domain}`)
+  const serviceAction = options.dnsmasqRunning ? 'restart' : 'start'
+
+  return [
+    'mkdir -p /etc/resolver',
+    `echo "nameserver ${options.dnsIp}" > ${resolverPath}`,
+    `${options.brewPrefix}/bin/brew services ${serviceAction} dnsmasq`,
+  ].join(' && ')
+}
+
 async function resolveInstallDomain(explicitDomain?: string): Promise<string> {
   if (explicitDomain !== undefined) {
     const normalized = normalizeDomain(explicitDomain)
@@ -151,39 +171,8 @@ async function installMacOS(dnsIp: string, domain: string, skipConfirm = false):
     }
   }
 
-  // Set up resolver first — this is what makes macOS dscacheutil (and
-  // therefore checkDns / `port up`) work.  Without /etc/resolver/<domain>,
-  // DNS resolution for *.<domain> won't use dnsmasq at all, even if the
-  // service is running correctly.
-  let resolverOk = true
-  try {
-    // Check if /etc/resolver already contains the correct config
-    const content = await fileOps.read(`/etc/resolver/${domain}`)
-    if (content.includes(`nameserver ${dnsIp}`)) {
-      output.dim(`Resolver already configured at /etc/resolver/${domain}`)
-    } else {
-      // File exists but has wrong content — overwrite it
-      await fileOps.write(`/etc/resolver/${domain}`, `nameserver ${dnsIp}`, { privileged: true })
-      output.success(`Resolver updated at /etc/resolver/${domain}`)
-    }
-  } catch {
-    // File doesn't exist or can't be read — create it
-    output.info(`Creating resolver for .${domain} domain...`)
-    try {
-      await fileOps.mkdir('/etc/resolver', { privileged: true })
-      await fileOps.write(`/etc/resolver/${domain}`, `nameserver ${dnsIp}`, { privileged: true })
-      output.success(`Resolver created at /etc/resolver/${domain}`)
-    } catch (error) {
-      output.error(`Failed to create resolver: ${error}`)
-      output.info('You can try running these commands manually:')
-      output.info('  sudo mkdir -p /etc/resolver')
-      output.info(`  echo "nameserver ${dnsIp}" | sudo tee /etc/resolver/${domain}`)
-      resolverOk = false
-    }
-  }
-
-  // Start or restart dnsmasq so it picks up any config changes
-  let serviceOk = true
+  // Set up the resolver and adjust the dnsmasq service in one privileged call
+  // so macOS only asks for admin credentials once.
   let dnsmasqRunning = false
   try {
     await execAsync('pgrep dnsmasq')
@@ -192,27 +181,29 @@ async function installMacOS(dnsIp: string, domain: string, skipConfirm = false):
     // pgrep returns non-zero if no process found
   }
 
-  const serviceCommand = dnsmasqRunning
-    ? `${brewPrefix}/bin/brew services restart dnsmasq`
-    : `${brewPrefix}/bin/brew services start dnsmasq`
+  const privilegedCommand = buildMacOSPrivilegedCommand({
+    brewPrefix,
+    dnsIp,
+    domain,
+    dnsmasqRunning,
+  })
 
-  if (dnsmasqRunning) {
-    output.info('Reloading dnsmasq service...')
-  } else {
-    output.info('Starting dnsmasq service...')
-  }
+  output.info(
+    dnsmasqRunning
+      ? 'Applying macOS DNS changes and restarting dnsmasq...'
+      : 'Applying macOS DNS changes and starting dnsmasq...'
+  )
 
   try {
-    await execPrivileged(serviceCommand)
+    await execPrivileged(privilegedCommand)
+    output.success(`Resolver configured at /etc/resolver/${domain}`)
     output.success(dnsmasqRunning ? 'dnsmasq service reloaded' : 'dnsmasq service started')
   } catch (error) {
-    output.error(`Failed to ${dnsmasqRunning ? 'reload' : 'start'} dnsmasq: ${error}`)
-    output.info('Run this command as an admin user:')
-    output.info(`  sudo ${serviceCommand}`)
-    serviceOk = false
+    output.error(`Failed to configure macOS DNS: ${error}`)
+    return false
   }
 
-  return resolverOk && serviceOk
+  return true
 }
 
 /**

--- a/src/commands/uninstall.test.ts
+++ b/src/commands/uninstall.test.ts
@@ -181,10 +181,12 @@ describe('uninstall command', () => {
     expect(mocks.execAsync).toHaveBeenCalledWith(
       "sed -i '' '/address=\\/port\\//d' /usr/local/etc/dnsmasq.conf"
     )
-    expect(mocks.execPrivileged).toHaveBeenCalledWith('rm /etc/resolver/port')
     expect(mocks.execPrivileged).toHaveBeenCalledWith(
-      '/usr/local/bin/brew services restart dnsmasq'
+      expect.stringContaining(
+        "rm '/etc/resolver/port' && /usr/local/bin/brew services restart dnsmasq"
+      )
     )
+    expect(mocks.execPrivileged).toHaveBeenCalledTimes(1)
     expect(mocks.execPrivileged).not.toHaveBeenCalledWith('systemctl restart systemd-resolved')
   })
 
@@ -211,7 +213,8 @@ describe('uninstall command', () => {
     expect(mocks.execAsync).toHaveBeenCalledWith(
       "sed -i '' '/address=\\/custom\\//d' /usr/local/etc/dnsmasq.conf"
     )
-    expect(mocks.execPrivileged).toHaveBeenCalledWith('rm /etc/resolver/custom')
+    expect(mocks.execPrivileged).toHaveBeenCalledWith("rm '/etc/resolver/custom'")
+    expect(mocks.execPrivileged).toHaveBeenCalledTimes(1)
     expect(mocks.checkDns).toHaveBeenNthCalledWith(2, 'custom', '127.0.0.1')
   })
 

--- a/src/commands/uninstall.ts
+++ b/src/commands/uninstall.ts
@@ -34,6 +34,33 @@ function normalizeDomain(domain: string): string {
   return domain.trim().toLowerCase()
 }
 
+function shellQuote(value: string): string {
+  return `'${value.replace(/'/g, `'"'"'`)}'`
+}
+
+function buildMacOSUninstallCommand(options: {
+  resolverPath: string
+  brewPrefix: string
+  resolverExists: boolean
+  dnsmasqRunning: boolean
+}): string | null {
+  const actions = []
+
+  if (options.resolverExists) {
+    actions.push(`rm ${shellQuote(options.resolverPath)}`)
+  }
+
+  if (options.dnsmasqRunning) {
+    actions.push(`${options.brewPrefix}/bin/brew services restart dnsmasq`)
+  }
+
+  if (actions.length === 0) {
+    return null
+  }
+
+  return actions.join(' && ')
+}
+
 async function resolveUninstallDomain(explicitDomain?: string): Promise<string> {
   if (explicitDomain !== undefined) {
     const normalized = normalizeDomain(explicitDomain)
@@ -89,22 +116,41 @@ async function uninstallMacOS(domain: string): Promise<boolean> {
 
   // Remove the resolver file
   output.info(`Removing resolver for .${domain} domain...`)
-  try {
-    if (!(await fileOps.exists(`/etc/resolver/${domain}`))) throw new Error('not found')
-    await fileOps.delete(`/etc/resolver/${domain}`, { privileged: true })
-    output.success(`Removed /etc/resolver/${domain}`)
-  } catch {
+  const resolverPath = `/etc/resolver/${domain}`
+  const resolverExists = await fileOps.exists(resolverPath)
+  if (!resolverExists) {
     output.dim(`No resolver file found at /etc/resolver/${domain}`)
   }
 
-  // Restart dnsmasq if it's running (to apply the config changes)
-  if (await isDnsmasqRunning()) {
+  const dnsmasqRunning = await isDnsmasqRunning()
+  const privilegedCommand = buildMacOSUninstallCommand({
+    resolverPath,
+    brewPrefix,
+    resolverExists,
+    dnsmasqRunning,
+  })
+
+  if (!privilegedCommand) {
+    return true
+  }
+
+  if (dnsmasqRunning) {
     output.info('Restarting dnsmasq to apply changes...')
-    try {
-      await execPrivileged(`${brewPrefix}/bin/brew services restart dnsmasq`)
+  }
+
+  try {
+    await execPrivileged(privilegedCommand)
+    if (resolverExists) {
+      output.success(`Removed /etc/resolver/${domain}`)
+    }
+    if (dnsmasqRunning) {
       output.success('dnsmasq restarted')
-    } catch (error) {
+    }
+  } catch (error) {
+    if (dnsmasqRunning) {
       output.warn(`Could not restart dnsmasq: ${error}`)
+    } else {
+      output.warn(`Could not remove resolver: ${error}`)
     }
   }
 


### PR DESCRIPTION
## Summary
- Batched macOS DNS setup into a single privileged command so install only prompts for admin credentials once.
- Updated install coverage to assert the one-call macOS flow for both dnsmasq start and restart paths.
## Testing
- `bunx vitest src/commands/install.test.ts`
- `bunx tsc --noEmit`
- `bunx prettier --check src/commands/install.ts src/commands/install.test.ts`
## Risks
- macOS privilege handling now depends on one combined shell command; failures surface as a single setup error.
- Linux install behavior was left unchanged.