### PR TITLE
Exit current worktree before pruning

### DIFF
--- a/src/commands/prune.test.ts
+++ b/src/commands/prune.test.ts
@@ -27,6 +27,7 @@ const mocks = vi.hoisted(() => ({
   scanDockerResourcesForProject: vi.fn(),
   getProjectName: vi.fn(),
   stopWorktreeServices: vi.fn(),
+  exit: vi.fn(),
 }))
 
 vi.mock('inquirer', () => ({
@@ -61,6 +62,10 @@ vi.mock('../lib/github.ts', () => ({
 vi.mock('../lib/removal.ts', () => ({
   removeWorktreeAndCleanup: mocks.removeWorktreeAndCleanup,
   stopWorktreeServices: mocks.stopWorktreeServices,
+}))
+
+vi.mock('./exit.ts', () => ({
+  exit: mocks.exit,
 }))
 
 vi.mock('../lib/sanitize.ts', () => ({
@@ -119,6 +124,7 @@ describe('prune command', () => {
 
     mocks.getProjectName.mockImplementation((_repoRoot: string, branch: string) => `port-${branch}`)
     mocks.stopWorktreeServices.mockResolvedValue(undefined)
+    mocks.exit.mockResolvedValue(undefined)
     mocks.cleanupDockerResources.mockResolvedValue({
       volumesRemoved: 0,
       networksRemoved: 0,
@@ -168,6 +174,31 @@ describe('prune command', () => {
         branchAction: 'archive',
         quiet: true,
       })
+    )
+  })
+
+  test('exits current worktree before pruning it', async () => {
+    mocks.detectWorktree.mockReturnValue({
+      repoRoot: '/repo',
+      worktreePath: '/repo/.port/trees/feature-a',
+      name: 'feature-a',
+      isMainRepo: false,
+    })
+
+    await prune({ force: true })
+
+    expect(mocks.exit).toHaveBeenCalled()
+    expect(mocks.exit.mock.invocationCallOrder[0]).toBeLessThan(
+      mocks.stopWorktreeServices.mock.invocationCallOrder[0]!
+    )
+    expect(mocks.stopWorktreeServices).toHaveBeenCalledWith(
+      {
+        repoRoot: '/repo',
+        composeFile: 'docker-compose.yml',
+        domain: 'port',
+      },
+      'feature-a',
+      expect.objectContaining({ quiet: true })
     )
   })
 

--- a/src/commands/prune.ts
+++ b/src/commands/prune.ts
@@ -15,6 +15,7 @@ import { failWithError } from '../lib/cli.ts'
 import { getProjectName } from '../lib/compose.ts'
 import { cleanupDockerResources, scanDockerResourcesForProject } from '../lib/docker-cleanup.ts'
 import * as output from '../lib/output.ts'
+import { exit } from './exit.ts'
 
 interface PruneOptions {
   dryRun?: boolean
@@ -113,8 +114,10 @@ function formatTimeAgo(isoDate: string): string {
  */
 export async function prune(options: PruneOptions = {}): Promise<void> {
   let repoRoot: string
+  let worktreeInfo: ReturnType<typeof detectWorktree>
   try {
-    repoRoot = detectWorktree().repoRoot
+    worktreeInfo = detectWorktree()
+    repoRoot = worktreeInfo.repoRoot
   } catch {
     failWithError('Not in a git repository')
   }
@@ -238,6 +241,16 @@ export async function prune(options: PruneOptions = {}): Promise<void> {
       output.info('Prune cancelled')
       return
     }
+  }
+
+  const currentWorktreeBranch = process.env.PORT_WORKTREE
+    ? sanitizeBranchName(process.env.PORT_WORKTREE)
+    : !worktreeInfo.isMainRepo
+      ? worktreeInfo.name
+      : undefined
+
+  if (currentWorktreeBranch && candidates.some(candidate => candidate.sanitized === currentWorktreeBranch)) {
+    await exit()
   }
 
   // 9. Remove each candidate

--- a/src/commands/prune.ts
+++ b/src/commands/prune.ts
@@ -249,7 +249,10 @@ export async function prune(options: PruneOptions = {}): Promise<void> {
       ? worktreeInfo.name
       : undefined
 
-  if (currentWorktreeBranch && candidates.some(candidate => candidate.sanitized === currentWorktreeBranch)) {
+  if (
+    currentWorktreeBranch &&
+    candidates.some(candidate => candidate.sanitized === currentWorktreeBranch)
+  ) {
     await exit()
   }
 


### PR DESCRIPTION
## Summary
- Ensures `port prune` exits the current worktree first when it is about to prune that same worktree.
- Adds a regression test covering the current-worktree prune path to prevent cwd-related failures.
## Testing
- `bunx vitest run src/commands/prune.test.ts src/commands/remove.test.ts src/commands/exit.test.ts`
- `bunx tsc --noEmit`
- Result: passed
## Risks
- None noted.
- Behavior changes only when the current worktree is also a prune candidate; normal prune flows are unchanged.