### PR TITLE
feat: reuse existing worktree on enter

### DIFF
--- a/ONBOARD.md
+++ b/ONBOARD.md
@@ -23,8 +23,8 @@ Port is a CLI for managing git worktrees that makes it easy to create, enter, an
 
 ### 4. `port enter <branch>`
 
-- **How**: Use explicit enter, especially when branch names match commands.
-- **Why**: Creates or enters the branch worktree and changes into it.
+- **How**: Use explicit enter, especially when branch names match commands or are already checked out elsewhere.
+- **Why**: Creates or enters the branch worktree and changes into it, reusing an existing checked-out worktree when needed.
 
 ### 5. `port up`
 

--- a/README.md
+++ b/README.md
@@ -152,6 +152,7 @@ port enter feature-1
 This creates a new worktree and changes into it (with shell integration) or prints the path to `cd` into.
 Use `port enter <branch>` when your branch name collides with a command (for example `status` or `install`).
 If a branch and command collide, running `port <command>` shows a hint to use `port enter <branch>`.
+If the branch is already checked out in another worktree, `port enter` reuses that worktree and tells you where it is.
 
 ### 7. Exit a Worktree
 

--- a/docs/superpowers/plans/2026-05-21-port-enter-duplicate-worktree-recovery.md
+++ b/docs/superpowers/plans/2026-05-21-port-enter-duplicate-worktree-recovery.md
@@ -1,0 +1,129 @@
+# Port Enter Duplicate Worktree Recovery Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make `port enter` recover gracefully when git reports that a branch is already checked out in another worktree, and document the behavior.
+
+**Architecture:** Add a small git helper that recognizes duplicate-worktree failures and extracts the existing worktree path from git's error text. `port enter` will use that helper to reuse the existing worktree instead of hard-failing, while preserving the normal shell-hook eval path and user-facing messages. Keep the change localized to the git helper, enter command, and docs/tests that already cover onboarding and command flow.
+
+**Tech Stack:** TypeScript, Vitest, simple-git, bun
+
+---
+
+### Task 1: Detect duplicate-worktree git failures
+
+**Files:**
+
+- Modify: `src/lib/git.ts`
+- Test: `src/lib/git.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+```ts
+import { describe, expect, test } from 'vitest'
+import { parseDuplicateWorktreeError } from './git.ts'
+
+describe('parseDuplicateWorktreeError', () => {
+  test('extracts branch and path from git duplicate-worktree output', () => {
+    const error = new Error(
+      "fatal: 'feature-1' is already used by worktree at '/repo/.port/trees/feature-1'"
+    )
+
+    expect(parseDuplicateWorktreeError(error)).toEqual({
+      branch: 'feature-1',
+      path: '/repo/.port/trees/feature-1',
+    })
+  })
+
+  test('returns null for unrelated git failures', () => {
+    expect(parseDuplicateWorktreeError(new Error('fatal: unrelated failure'))).toBeNull()
+  })
+})
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `bun run test src/lib/git.test.ts`
+Expected: FAIL because `parseDuplicateWorktreeError` does not exist yet.
+
+- [ ] **Step 3: Write minimal implementation**
+
+Add `parseDuplicateWorktreeError(error: unknown)` to `src/lib/git.ts` and export it.
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `bun run test src/lib/git.test.ts`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/lib/git.ts src/lib/git.test.ts
+git commit -m "feat: parse duplicate worktree errors"
+```
+
+### Task 2: Reuse the existing worktree in `port enter`
+
+**Files:**
+
+- Modify: `src/commands/enter.ts`
+- Test: `src/commands/enter.command.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+Add a test where `createWorktree()` rejects with a duplicate-worktree git error and `enter()` logs a message that it is using the existing worktree path instead of exiting.
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `bun run test src/commands/enter.command.test.ts`
+Expected: FAIL because the duplicate-worktree branch is not handled.
+
+- [ ] **Step 3: Write minimal implementation**
+
+In `enter()`, catch duplicate-worktree failures, log a clear reuse message, and continue with the resolved path.
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `bun run test src/commands/enter.command.test.ts`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/commands/enter.ts src/commands/enter.command.test.ts
+git commit -m "feat: reuse existing worktree on enter"
+```
+
+### Task 3: Document the new behavior
+
+**Files:**
+
+- Modify: `README.md`
+- Modify: `ONBOARD.md`
+- Modify: `src/commands/onboard.ts`
+- Test: `src/commands/onboard.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+Update the onboarding text expectation so the `port enter <branch>` entry explains that Port can reuse an existing checked-out worktree.
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `bun run test src/commands/onboard.test.ts`
+Expected: FAIL until the onboarding copy is updated.
+
+- [ ] **Step 3: Write minimal implementation**
+
+Update the onboarding copy in `src/commands/onboard.ts`, then mirror it into `ONBOARD.md` and the README enter section.
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `bun run test src/commands/onboard.test.ts`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add README.md ONBOARD.md src/commands/onboard.ts src/commands/onboard.test.ts
+git commit -m "docs: describe duplicate worktree reuse"
+```

--- a/src/commands/__snapshots__/onboard.test.ts.snap
+++ b/src/commands/__snapshots__/onboard.test.ts.snap
@@ -26,8 +26,8 @@ Port is a CLI for managing git worktrees that makes it easy to create, enter, an
 
 ### 4. \`port enter <branch>\`
 
-- **How**: Use explicit enter, especially when branch names match commands.
-- **Why**: Creates or enters the branch worktree and changes into it.
+- **How**: Use explicit enter, especially when branch names match commands or are already checked out elsewhere.
+- **Why**: Creates or enters the branch worktree and changes into it, reusing an existing checked-out worktree when needed.
 
 ### 5. \`port up\`
 
@@ -105,8 +105,8 @@ Port is a CLI for managing git worktrees that makes it easy to create, enter, an
 
 ### 4. \`port enter <branch>\`
 
-- **How**: Use explicit enter, especially when branch names match commands.
-- **Why**: Creates or enters the branch worktree and changes into it.
+- **How**: Use explicit enter, especially when branch names match commands or are already checked out elsewhere.
+- **Why**: Creates or enters the branch worktree and changes into it, reusing an existing checked-out worktree when needed.
 
 ### 5. \`port up\`
 

--- a/src/commands/enter.command.test.ts
+++ b/src/commands/enter.command.test.ts
@@ -12,6 +12,7 @@ const mocks = vi.hoisted(() => ({
   createWorktree: vi.fn(),
   remoteBranchExists: vi.fn(),
   removeWorktree: vi.fn(),
+  parseDuplicateWorktreeError: vi.fn(),
   writeOverrideFile: vi.fn(),
   parseComposeFile: vi.fn(),
   getProjectName: vi.fn(),
@@ -52,6 +53,7 @@ vi.mock('../lib/git.ts', () => ({
   createWorktree: mocks.createWorktree,
   remoteBranchExists: mocks.remoteBranchExists,
   removeWorktree: mocks.removeWorktree,
+  parseDuplicateWorktreeError: mocks.parseDuplicateWorktreeError,
 }))
 
 vi.mock('../lib/compose.ts', () => ({
@@ -130,6 +132,7 @@ describe('enter typo confirmation', () => {
     mocks.remoteBranchExists.mockResolvedValue(false)
     mocks.findSimilarCommand.mockReturnValue({ command: 'install', distance: 1, similarity: 0.86 })
     mocks.createWorktree.mockResolvedValue('/repo/.port/trees/instal')
+    mocks.parseDuplicateWorktreeError.mockReturnValue(null)
     mocks.hookExists.mockResolvedValue(false)
     mocks.parseComposeFile.mockRejectedValue(new Error('compose missing'))
     mocks.getProjectName.mockReturnValue('repo-instal')
@@ -235,6 +238,35 @@ describe('enter typo confirmation', () => {
 
     expect(mocks.prompt).not.toHaveBeenCalled()
     expect(mocks.createWorktree).toHaveBeenCalledWith('/repo', 'status')
+  })
+
+  test('reuses an existing worktree when git reports that the branch is already checked out', async () => {
+    mocks.createWorktree.mockRejectedValueOnce(
+      new Error(
+        "fatal: 'shared' is already used by worktree at '/repo/.port/trees/shared-external'"
+      )
+    )
+    mocks.parseDuplicateWorktreeError.mockReturnValue({
+      branch: 'shared',
+      path: '/repo/.port/trees/shared-external',
+    })
+    mocks.parseComposeFile.mockResolvedValue({ services: {} })
+    mocks.getProjectName.mockReturnValue('repo-shared')
+
+    await enter('shared')
+
+    expect(mocks.parseDuplicateWorktreeError).toHaveBeenCalledWith(expect.any(Error))
+    expect(mocks.warn).toHaveBeenCalledWith(
+      'Branch "shared" is already checked out in another worktree; using /repo/.port/trees/shared-external'
+    )
+    expect(mocks.writeOverrideFile).toHaveBeenCalledWith(
+      '/repo/.port/trees/shared-external',
+      { services: {} },
+      'shared',
+      'port',
+      'repo-shared'
+    )
+    expect(mocks.createWorktree).toHaveBeenCalledWith('/repo', 'shared')
   })
 
   test('warns when creating a new worktree and the stale count is extreme', async () => {

--- a/src/commands/enter.test.ts
+++ b/src/commands/enter.test.ts
@@ -2,6 +2,7 @@ import { existsSync } from 'fs'
 import { join } from 'path'
 import { execPortAsync, fetchWithTimeout, prepareSample, safeDown } from '@tests/utils'
 import { describe, test, expect } from 'vitest'
+import { execAsync } from '../lib/exec'
 
 const TIMEOUT = 240000
 const POLL_TIMEOUT = 150000
@@ -95,6 +96,33 @@ describe('parallel worktrees', () => {
       } finally {
         await safeDown(worktreeADir)
         await safeDown(worktreeBDir)
+        await sample.cleanup()
+      }
+    },
+    TIMEOUT + 1000
+  )
+
+  test(
+    'reuses an existing worktree outside .port/trees when the branch is already checked out',
+    async () => {
+      const sample = await prepareSample('db-and-server', {
+        gitInit: true,
+      })
+
+      const branch = 'shared-reuse'
+      const externalWorktreeDir = join(sample.dir, 'external-worktree')
+
+      try {
+        await execAsync(`git worktree add "${externalWorktreeDir}" -b "${branch}"`, {
+          cwd: sample.dir,
+        })
+
+        const result = await execPortAsync(['enter', branch], sample.dir)
+
+        expect(result.stderr).toContain('already checked out in another worktree')
+        expect(result.stderr).toContain(externalWorktreeDir)
+        expect(existsSync(join(externalWorktreeDir, '.port', 'override.yml'))).toBe(true)
+      } finally {
         await sample.cleanup()
       }
     },

--- a/src/commands/enter.ts
+++ b/src/commands/enter.ts
@@ -6,7 +6,13 @@ import {
   getComposeFile,
   ensurePortRuntimeDir,
 } from '../lib/config.ts'
-import { branchExists, createWorktree, remoteBranchExists, removeWorktree } from '../lib/git.ts'
+import {
+  branchExists,
+  createWorktree,
+  parseDuplicateWorktreeError,
+  remoteBranchExists,
+  removeWorktree,
+} from '../lib/git.ts'
 import { writeOverrideFile, parseComposeFile, getProjectName } from '../lib/compose.ts'
 import { sanitizeBranchName } from '../lib/sanitize.ts'
 import { hookExists, runPostCreateHook } from '../lib/hooks.ts'
@@ -126,8 +132,17 @@ export async function enter(branch: string): Promise<void> {
       isNewWorktree = true
       output.success(`Created worktree: ${sanitized}`)
     } catch (error) {
-      output.error(`Failed to create worktree: ${error}`)
-      process.exit(1)
+      const duplicateWorktree = parseDuplicateWorktreeError(error)
+
+      if (!duplicateWorktree) {
+        output.error(`Failed to create worktree: ${error}`)
+        process.exit(1)
+      }
+
+      worktreePath = duplicateWorktree.path
+      output.warn(
+        `Branch "${sanitized}" is already checked out in another worktree; using ${worktreePath}`
+      )
     }
   }
 

--- a/src/commands/onboard.test.ts
+++ b/src/commands/onboard.test.ts
@@ -59,10 +59,10 @@ describe('onboard command', () => {
     expect(mocks.header).toHaveBeenCalledWith(expect.stringContaining('port exit'))
     expect(mocks.header).toHaveBeenCalledWith(expect.stringContaining('port remove'))
     expect(mocks.dim).toHaveBeenCalledWith(
-      '   How: Use explicit enter, especially when branch names match commands.'
+      '   How: Use explicit enter, especially when branch names match commands or are already checked out elsewhere.'
     )
     expect(mocks.dim).toHaveBeenCalledWith(
-      '   Why: Stops project services and offers Traefik shutdown when appropriate.'
+      '   Why: Creates or enters the branch worktree and changes into it, reusing an existing checked-out worktree when needed.'
     )
     expect(mocks.info).toHaveBeenCalledWith('Useful checks:')
   })

--- a/src/commands/onboard.ts
+++ b/src/commands/onboard.ts
@@ -27,8 +27,8 @@ const STEPS: OnboardStep[] = [
   },
   {
     command: 'port enter <branch>',
-    how: 'Use explicit enter, especially when branch names match commands.',
-    why: 'Creates or enters the branch worktree and changes into it.',
+    how: 'Use explicit enter, especially when branch names match commands or are already checked out elsewhere.',
+    why: 'Creates or enters the branch worktree and changes into it, reusing an existing checked-out worktree when needed.',
   },
   {
     command: 'port up',

--- a/src/lib/git.test.ts
+++ b/src/lib/git.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, test } from 'vitest'
+import { parseDuplicateWorktreeError } from './git.ts'
+
+describe('parseDuplicateWorktreeError', () => {
+  test('extracts branch and path from duplicate-worktree output', () => {
+    const error = new Error(
+      "fatal: 'feature-1' is already used by worktree at '/repo/.port/trees/feature-1'"
+    )
+
+    expect(parseDuplicateWorktreeError(error)).toEqual({
+      branch: 'feature-1',
+      path: '/repo/.port/trees/feature-1',
+    })
+  })
+
+  test('returns null for unrelated failures', () => {
+    expect(parseDuplicateWorktreeError(new Error('fatal: unrelated failure'))).toBeNull()
+  })
+})

--- a/src/lib/git.ts
+++ b/src/lib/git.ts
@@ -13,6 +13,37 @@ export class GitError extends Error {
   }
 }
 
+export interface DuplicateWorktreeErrorInfo {
+  branch: string
+  path: string
+}
+
+const DUPLICATE_WORKTREE_PATTERNS = [
+  /['"](?<branch>[^'"\n]+)['"]\s+is already used by worktree at\s+['"](?<path>[^'"\n]+)['"]/i,
+  /['"](?<branch>[^'"\n]+)['"]\s+is already checked out at\s+['"](?<path>[^'"\n]+)['"]/i,
+]
+
+export function parseDuplicateWorktreeError(error: unknown): DuplicateWorktreeErrorInfo | null {
+  const text =
+    error instanceof Error
+      ? `${error.message}\n${(error as { stderr?: string }).stderr ?? ''}`
+      : String(error)
+
+  for (const pattern of DUPLICATE_WORKTREE_PATTERNS) {
+    const match = text.match(pattern)
+    const groups = match?.groups as { branch?: string; path?: string } | undefined
+
+    if (groups?.branch && groups.path) {
+      return {
+        branch: groups.branch,
+        path: groups.path,
+      }
+    }
+  }
+
+  return null
+}
+
 /**
  * Get a simple-git instance for a repository
  */


### PR DESCRIPTION
## Summary
- `port enter` now detects when a branch is already checked out in another worktree and reuses that worktree instead of failing.
- Added coverage for duplicate-worktree parsing and enter-flow recovery, and updated onboarding/README docs to describe the new behavior.
## Testing
- Ran `bun run test src/lib/git.test.ts src/commands/enter.command.test.ts src/commands/enter.test.ts src/commands/onboard.test.ts`
- Ran `bun run typecheck`
- Result: passed
## Risks
- Existing worktree paths may now be reused automatically when a branch collision is detected; the warning message is the main safeguard.
- No rollout concerns beyond user-facing behavior change in `port enter`.