### PR TITLE
Add service aliases to compose routing

### DIFF
--- a/README.md
+++ b/README.md
@@ -623,16 +623,16 @@ docker compose -p <project-name> -f docker-compose.yml -f .port/override.yml -f 
 
 Here are all Port-managed overrides/compose controls and why they exist:
 
-| Port-managed change                                                       | Why it is necessary                                                                                                  |
-| ------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------- |
-| `-p <project-name>` (compose flag)                                        | Namespaces compose resources per repo/worktree so similarly named stacks do not collide.                             |
-| `-f .port/override.yml` (compose flag)                                    | Applies Port's deterministic runtime adjustments without mutating your source compose file.                          |
-| `-f .port/override.user.yml` (compose flag, optional)                     | Applies user-provided overrides rendered from `.port/override-compose.yml`, after Port defaults, so user rules win.  |
-| `services.<name>.ports: !override []` (for services with published ports) | Removes host port binds so two worktrees can both run services that declare the same host ports.                     |
+| Port-managed change                                                       | Why it is necessary                                                                                                                                                  |
+| ------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `-p <project-name>` (compose flag)                                        | Namespaces compose resources per repo/worktree so similarly named stacks do not collide.                                                                             |
+| `-f .port/override.yml` (compose flag)                                    | Applies Port's deterministic runtime adjustments without mutating your source compose file.                                                                          |
+| `-f .port/override.user.yml` (compose flag, optional)                     | Applies user-provided overrides rendered from `.port/override-compose.yml`, after Port defaults, so user rules win.                                                  |
+| `services.<name>.ports: !override []` (for services with published ports) | Removes host port binds so two worktrees can both run services that declare the same host ports.                                                                     |
 | `services.<name>.labels: [...]`                                           | Adds Traefik router/service metadata so requests route by hostname (`<branch>.port`) and service aliases (`<service>.<branch>.port`) instead of host port ownership. |
-| `services.<name>.networks: [traefik-network]`                             | Ensures Traefik can reach exposed services on the shared network.                                                    |
-| `services.<name>.container_name` rewrite (only when upstream sets one)    | Prevents global Docker container name conflicts when upstream hard-codes a fixed `container_name`.                   |
-| `networks.traefik-network.external: true`                                 | Connects project services to the globally managed Traefik network instead of creating per-project duplicates.        |
+| `services.<name>.networks: [traefik-network]`                             | Ensures Traefik can reach exposed services on the shared network.                                                                                                    |
+| `services.<name>.container_name` rewrite (only when upstream sets one)    | Prevents global Docker container name conflicts when upstream hard-codes a fixed `container_name`.                                                                   |
+| `networks.traefik-network.external: true`                                 | Connects project services to the globally managed Traefik network instead of creating per-project duplicates.                                                        |
 
 Notes:
 

--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ port up
 - **Host Process Support**: Run non-Docker processes (like `npm serve`) with Traefik routing
 - **DNS Setup**: Automated DNS configuration for `*.port` domains
 - **Service Discovery**: Easy access to services via hostnames instead of port numbers
+- **Service Name Aliases**: First published ports are also available at `service.<branch>.port`
 - **Lifecycle Hooks**: Run custom scripts after worktree creation and after `port up`
 
 ## Installation
@@ -168,6 +169,7 @@ port up
 ```
 
 Starts docker-compose services and makes them available at `feature-1.port:PORT`.
+For services with published ports, the first one is also reachable at `service.feature-1.port`.
 
 If `.port/hooks/post-up.sh` is executable, Port runs it after services are up. You can manually
 rerun that hook with:
@@ -627,7 +629,7 @@ Here are all Port-managed overrides/compose controls and why they exist:
 | `-f .port/override.yml` (compose flag)                                    | Applies Port's deterministic runtime adjustments without mutating your source compose file.                          |
 | `-f .port/override.user.yml` (compose flag, optional)                     | Applies user-provided overrides rendered from `.port/override-compose.yml`, after Port defaults, so user rules win.  |
 | `services.<name>.ports: !override []` (for services with published ports) | Removes host port binds so two worktrees can both run services that declare the same host ports.                     |
-| `services.<name>.labels: [...]`                                           | Adds Traefik router/service metadata so requests route by hostname (`<branch>.port`) instead of host port ownership. |
+| `services.<name>.labels: [...]`                                           | Adds Traefik router/service metadata so requests route by hostname (`<branch>.port`) and service aliases (`<service>.<branch>.port`) instead of host port ownership. |
 | `services.<name>.networks: [traefik-network]`                             | Ensures Traefik can reach exposed services on the shared network.                                                    |
 | `services.<name>.container_name` rewrite (only when upstream sets one)    | Prevents global Docker container name conflicts when upstream hard-codes a fixed `container_name`.                   |
 | `networks.traefik-network.external: true`                                 | Connects project services to the globally managed Traefik network instead of creating per-project duplicates.        |

--- a/src/commands/urls.test.ts
+++ b/src/commands/urls.test.ts
@@ -92,8 +92,38 @@ describe('urls command', () => {
 
     expect(mocks.header).toHaveBeenCalledWith('Service URLs for feature-1:')
     expect(mocks.serviceUrls).toHaveBeenCalledWith([
-      { name: 'web', urls: ['http://feature-1.port:3000'], running: false },
-      { name: 'db', urls: ['http://feature-1.port:5432'], running: false },
+      {
+        name: 'web',
+        urls: ['http://web.feature-1.port', 'http://feature-1.port:3000'],
+        running: false,
+      },
+      {
+        name: 'db',
+        urls: ['http://db.feature-1.port', 'http://feature-1.port:5432'],
+        running: false,
+      },
+    ])
+  })
+
+  test('includes a service-name alias for the first published port', async () => {
+    const web = {}
+
+    mocks.parseComposeFile.mockResolvedValue({
+      name: 'repo',
+      services: {
+        web,
+      },
+    })
+    mocks.getServicePorts.mockReturnValue([3000, 3001])
+
+    await urls()
+
+    expect(mocks.serviceUrls).toHaveBeenCalledWith([
+      {
+        name: 'web',
+        urls: ['http://web.feature-1.port', 'http://feature-1.port:3000', 'http://feature-1.port:3001'],
+        running: false,
+      },
     ])
   })
 
@@ -117,7 +147,11 @@ describe('urls command', () => {
     await urls('web')
 
     expect(mocks.serviceUrls).toHaveBeenCalledWith([
-      { name: 'web', urls: ['http://feature-1.port:3000'], running: false },
+      {
+        name: 'web',
+        urls: ['http://web.feature-1.port', 'http://feature-1.port:3000'],
+        running: false,
+      },
     ])
   })
 
@@ -155,7 +189,11 @@ describe('urls command', () => {
 
     expect(mocks.header).toHaveBeenCalledWith('Service URLs for repo:')
     expect(mocks.serviceUrls).toHaveBeenCalledWith([
-      { name: 'web', urls: ['http://repo.port:3000'], running: false },
+      {
+        name: 'web',
+        urls: ['http://web.repo.port', 'http://repo.port:3000'],
+        running: false,
+      },
     ])
   })
 
@@ -183,8 +221,16 @@ describe('urls command', () => {
     await urls()
 
     expect(mocks.serviceUrls).toHaveBeenCalledWith([
-      { name: 'web', urls: ['http://feature-1.port:3000'], running: true },
-      { name: 'db', urls: ['http://feature-1.port:5432'], running: false },
+      {
+        name: 'web',
+        urls: ['http://web.feature-1.port', 'http://feature-1.port:3000'],
+        running: true,
+      },
+      {
+        name: 'db',
+        urls: ['http://db.feature-1.port', 'http://feature-1.port:5432'],
+        running: false,
+      },
     ])
   })
 })

--- a/src/commands/urls.test.ts
+++ b/src/commands/urls.test.ts
@@ -121,7 +121,11 @@ describe('urls command', () => {
     expect(mocks.serviceUrls).toHaveBeenCalledWith([
       {
         name: 'web',
-        urls: ['http://web.feature-1.port', 'http://feature-1.port:3000', 'http://feature-1.port:3001'],
+        urls: [
+          'http://web.feature-1.port',
+          'http://feature-1.port:3000',
+          'http://feature-1.port:3001',
+        ],
         running: false,
       },
     ])

--- a/src/commands/urls.ts
+++ b/src/commands/urls.ts
@@ -52,9 +52,12 @@ export async function urls(serviceName?: string): Promise<void> {
       const running = Array.from(runningServices.entries()).some(
         ([containerName, isRunning]) => containerName.includes(service) && isRunning
       )
+      const urls = ports.length > 0 ? [`http://${service}.${name}.${config.domain}`] : []
+      urls.push(...ports.map(port => `http://${name}.${config.domain}:${port}`))
+
       return {
         name: service,
-        urls: ports.map(port => `http://${name}.${config.domain}:${port}`),
+        urls,
         running,
       }
     })

--- a/src/lib/compose.test.ts
+++ b/src/lib/compose.test.ts
@@ -81,6 +81,29 @@ describe('generateOverrideContent', () => {
     )
   })
 
+  test('adds a service-name alias on web for the first published port', () => {
+    const parsedCompose: ParsedComposeFile = {
+      name: 'demo',
+      services: {
+        web: {
+          ports: [
+            { published: 3000, target: 3000 },
+            { published: 3001, target: 3001 },
+          ],
+        },
+      },
+    }
+
+    const override = generateOverrideContent(parsedCompose, 'feature-1', 'port')
+
+    expect(override).toContain('traefik.http.routers.feature-1-web-alias.rule=Host(`web.feature-1.port`)')
+    expect(override).toContain('traefik.http.routers.feature-1-web-alias.entrypoints=web')
+    expect(override).toContain(
+      'traefik.http.services.feature-1-web-alias.loadbalancer.server.port=3000'
+    )
+    expect(override).not.toContain('traefik.http.services.feature-1-web-alias.loadbalancer.server.port=3001')
+  })
+
   test('keeps separate mappings when published and target differ', () => {
     const parsedCompose: ParsedComposeFile = {
       name: 'layerone',

--- a/src/lib/compose.test.ts
+++ b/src/lib/compose.test.ts
@@ -96,12 +96,16 @@ describe('generateOverrideContent', () => {
 
     const override = generateOverrideContent(parsedCompose, 'feature-1', 'port')
 
-    expect(override).toContain('traefik.http.routers.feature-1-web-alias.rule=Host(`web.feature-1.port`)')
+    expect(override).toContain(
+      'traefik.http.routers.feature-1-web-alias.rule=Host(`web.feature-1.port`)'
+    )
     expect(override).toContain('traefik.http.routers.feature-1-web-alias.entrypoints=web')
     expect(override).toContain(
       'traefik.http.services.feature-1-web-alias.loadbalancer.server.port=3000'
     )
-    expect(override).not.toContain('traefik.http.services.feature-1-web-alias.loadbalancer.server.port=3001')
+    expect(override).not.toContain(
+      'traefik.http.services.feature-1-web-alias.loadbalancer.server.port=3001'
+    )
   })
 
   test('keeps separate mappings when published and target differ', () => {

--- a/src/lib/compose.ts
+++ b/src/lib/compose.ts
@@ -364,9 +364,30 @@ function generateTraefikHttpLabels(
   const routerName = `${worktreeName}-${serviceName}-${publishedPort}`
   const hostname = `${worktreeName}.${domain}`
 
+  return generateTraefikHttpRouterLabels(routerName, hostname, `port${publishedPort}`, targetPort)
+}
+
+function generateTraefikHttpAliasLabels(
+  worktreeName: string,
+  serviceName: string,
+  targetPort: number,
+  domain: string
+): string[] {
+  const routerName = `${worktreeName}-${serviceName}-alias`
+  const hostname = `${serviceName}.${worktreeName}.${domain}`
+
+  return generateTraefikHttpRouterLabels(routerName, hostname, 'web', targetPort)
+}
+
+function generateTraefikHttpRouterLabels(
+  routerName: string,
+  hostname: string,
+  entryPoint: string,
+  targetPort: number
+): string[] {
   return [
     `traefik.http.routers.${routerName}.rule=Host(\`${hostname}\`)`,
-    `traefik.http.routers.${routerName}.entrypoints=port${publishedPort}`,
+    `traefik.http.routers.${routerName}.entrypoints=${entryPoint}`,
     `traefik.http.routers.${routerName}.service=${routerName}`,
     `traefik.http.services.${routerName}.loadbalancer.server.port=${targetPort}`,
   ]
@@ -403,12 +424,19 @@ function generateTraefikLabels(
   serviceName: string,
   publishedPort: number,
   targetPort: number,
-  domain: string
+  domain: string,
+  includeAlias: boolean
 ): string[] {
-  return [
+  const labels = [
     ...generateTraefikHttpLabels(worktreeName, serviceName, publishedPort, targetPort, domain),
     ...generateTraefikTcpLabels(worktreeName, serviceName, publishedPort, targetPort, domain),
   ]
+
+  if (includeAlias) {
+    labels.unshift(...generateTraefikHttpAliasLabels(worktreeName, serviceName, targetPort, domain))
+  }
+
+  return labels
 }
 
 /**
@@ -443,7 +471,14 @@ export function generateOverrideContent(
       // Add labels for each port
       for (const port of ports) {
         labels.push(
-          ...generateTraefikLabels(worktreeName, serviceName, port.published, port.target, domain)
+          ...generateTraefikLabels(
+            worktreeName,
+            serviceName,
+            port.published,
+            port.target,
+            domain,
+            port === ports[0]
+          )
         )
       }
 

--- a/tests/samples/multi-port-server/.dockerignore
+++ b/tests/samples/multi-port-server/.dockerignore
@@ -1,0 +1,3 @@
+.git
+.port
+node_modules

--- a/tests/samples/multi-port-server/Dockerfile
+++ b/tests/samples/multi-port-server/Dockerfile
@@ -1,0 +1,7 @@
+FROM oven/bun:latest
+
+WORKDIR /app
+
+COPY . .
+
+CMD ["bun", "run", "index.ts"]

--- a/tests/samples/multi-port-server/docker-compose.yml
+++ b/tests/samples/multi-port-server/docker-compose.yml
@@ -1,0 +1,7 @@
+services:
+  app:
+    build: .
+    image: port-test-multi-port-server
+    ports:
+      - '3000:3000'
+      - '3001:3001'

--- a/tests/samples/multi-port-server/index.ts
+++ b/tests/samples/multi-port-server/index.ts
@@ -1,0 +1,15 @@
+function startServer(port: number, label: string): void {
+  Bun.serve({
+    port,
+    fetch() {
+      return new Response(label, {
+        headers: { 'Content-Type': 'text/plain' },
+      })
+    },
+  })
+}
+
+startServer(3000, 'primary')
+startServer(3001, 'secondary')
+
+console.log('Listening on ports 3000 and 3001')

--- a/tests/samples/multi-port-server/package.json
+++ b/tests/samples/multi-port-server/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "multi-port-server",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "bun run index.ts"
+  }
+}

--- a/tests/subdomain-aliases.test.ts
+++ b/tests/subdomain-aliases.test.ts
@@ -1,0 +1,77 @@
+import { describe, expect, test } from 'vitest'
+import { execPortAsync, fetchWithTimeout, prepareSample, safeDown } from './utils'
+
+const TIMEOUT = 240000
+
+async function fetchTextUntilReady(url: string, expectedText: string): Promise<string> {
+  const start = Date.now()
+
+  while (Date.now() - start < TIMEOUT) {
+    try {
+      const response = await fetchWithTimeout(url)
+      if (response.status === 200) {
+        const text = await response.text()
+        if (text.includes(expectedText)) {
+          return text
+        }
+      }
+    } catch {
+      // Not ready yet.
+    }
+
+    await new Promise(resolve => setTimeout(resolve, 1000))
+  }
+
+  throw new Error(`Timed out waiting for ${url}`)
+}
+
+describe('service-name subdomain aliases', () => {
+  test(
+    'routes a single-port service name alias to the app',
+    async () => {
+      const sample = await prepareSample('nextjs-app', { initWithConfig: true })
+
+      try {
+        await execPortAsync(['up'], sample.dir)
+
+        const branchHost = new URL(sample.urlWithPort(3000)).hostname
+        const canonicalUrl = `${sample.urlWithPort(3000)}/api/id`
+        const aliasUrl = `http://app.${branchHost}/api/id`
+
+        const canonical = await fetchTextUntilReady(canonicalUrl, 'id')
+        const alias = await fetchTextUntilReady(aliasUrl, 'id')
+
+        expect(alias).toBe(canonical)
+      } finally {
+        await safeDown(sample.dir)
+        await sample.cleanup()
+      }
+    },
+    TIMEOUT
+  )
+
+  test(
+    'routes the service alias to the first published port for multi-port services',
+    async () => {
+      const sample = await prepareSample('multi-port-server', { initWithConfig: true })
+
+      try {
+        await execPortAsync(['up'], sample.dir)
+
+        const branchHost = new URL(sample.urlWithPort(3000)).hostname
+        const aliasUrl = `http://app.${branchHost}`
+        const primaryUrl = sample.urlWithPort(3000)
+
+        const alias = await fetchTextUntilReady(aliasUrl, 'primary')
+        const primary = await fetchTextUntilReady(primaryUrl, 'primary')
+
+        expect(alias).toBe('primary')
+        expect(primary).toBe('primary')
+      } finally {
+        await safeDown(sample.dir)
+        await sample.cleanup()
+      }
+    },
+    TIMEOUT
+  )
+})


### PR DESCRIPTION
## Summary
- Add service-name Traefik aliases for Docker Compose services using the first published port, while keeping canonical `branch.port:PORT` access for every published port.
- Update `port urls` output and docs so the CLI and README reflect the new alias behavior.
- Add unit, integration, and e2e coverage for alias routing, including a new multi-port sample app.
## Testing
- `bunx vitest run src/lib/compose.test.ts src/commands/urls.test.ts tests/subdomain-aliases.test.ts`
- `bunx vitest run tests/urls.test.ts`
- `bunx vitest run tests/nextjs.test.ts`
- `bunx vitest run tests/compose.test.ts`
- `bunx tsc --noEmit`
- `bunx eslint src/lib/compose.ts src/commands/urls.ts src/lib/compose.test.ts src/commands/urls.test.ts tests/subdomain-aliases.test.ts tests/samples/multi-port-server/index.ts`
## Risks
- The alias always points at the first published port, which is deterministic but still a convention and may not match every service's intended "main" port.
- E2E coverage depends on Docker/Traefik being available locally or in CI.