### PR TITLE
chore: bump version to 0.2.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jdtzmn/port",
-  "version": "0.1.5",
+  "version": "0.2.0",
   "description": "CLI tool for managing git worktrees with automatic Traefik configuration",
   "author": "Jacob Daitzman <jdtzmn@gmail.com>",
   "repository": {


### PR DESCRIPTION
## Summary
- Bumped the package version from `0.1.5` to `0.2.0` in `package.json`.
- Prepared the repository for the `v0.2.0` release branch.
## Testing
- Not run; this change only updates package metadata.
## Risks
- None noted.
- Low risk: version-only change with no runtime impact.