### PR TITLE
Consolidate early-work skipping for enter and shell-hook

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -25,7 +25,11 @@ import { shellHook } from './commands/shell-hook.ts'
 import { completion } from './commands/completion.ts'
 import { hook } from './commands/hook.ts'
 import { open } from './commands/open.ts'
-import { isReservedCommand, shouldAutoRegisterWorktree } from './lib/commands.ts'
+import {
+  isReservedCommand,
+  shouldAutoRegisterWorktree,
+  shouldSkipEarlyWork,
+} from './lib/commands.ts'
 import { ensureCurrentWorktreeRegistered } from './lib/worktreeRegistration.ts'
 import { detectWorktree } from './lib/worktree.ts'
 import { branchExists } from './lib/git.ts'
@@ -48,7 +52,7 @@ function getCliVersion(): string {
 async function maybeWarnCommandBranchCollision(): Promise<void> {
   const token = process.argv[2]
 
-  if (!token || token.startsWith('-') || token === 'enter' || token === 'shell-hook') {
+  if (!token || token.startsWith('-') || shouldSkipEarlyWork(token)) {
     return
   }
 

--- a/src/lib/commands.test.ts
+++ b/src/lib/commands.test.ts
@@ -9,6 +9,7 @@ import {
   getGlobalFlags,
   getCommandDescriptions,
   shouldAutoRegisterWorktree,
+  shouldSkipEarlyWork,
 } from './commands.ts'
 
 describe('command name helpers', () => {
@@ -169,6 +170,7 @@ describe('shouldAutoRegisterWorktree', () => {
 
   test('skips global-only commands and flags', () => {
     expect(shouldAutoRegisterWorktree('help')).toBe(false)
+    expect(shouldAutoRegisterWorktree('enter')).toBe(false)
     expect(shouldAutoRegisterWorktree('completion')).toBe(false)
     expect(shouldAutoRegisterWorktree('install')).toBe(false)
     expect(shouldAutoRegisterWorktree('cleanup')).toBe(false)
@@ -176,5 +178,15 @@ describe('shouldAutoRegisterWorktree', () => {
     expect(shouldAutoRegisterWorktree('uninstall')).toBe(false)
     expect(shouldAutoRegisterWorktree('--help')).toBe(false)
     expect(shouldAutoRegisterWorktree('-V')).toBe(false)
+  })
+})
+
+describe('shouldSkipEarlyWork', () => {
+  test('skips pre-parse work for enter, completion, and shell-hook', () => {
+    expect(shouldSkipEarlyWork('enter')).toBe(true)
+    expect(shouldSkipEarlyWork('completion')).toBe(true)
+    expect(shouldSkipEarlyWork('shell-hook')).toBe(true)
+    expect(shouldSkipEarlyWork('status')).toBe(false)
+    expect(shouldSkipEarlyWork(undefined)).toBe(false)
   })
 })

--- a/src/lib/commands.ts
+++ b/src/lib/commands.ts
@@ -28,6 +28,14 @@ export const NON_WORKTREE_COMMANDS = new Set([
   'shell-hook',
 ])
 
+/**
+ * Commands that should skip any work done before Commander parses the command.
+ *
+ * Use this for startup-time checks that should not run for commands like
+ * `enter`, `completion`, or `shell-hook`.
+ */
+const SKIP_EARLY_WORK_COMMANDS = new Set(['enter', 'completion', 'shell-hook'])
+
 // ---------------------------------------------------------------------------
 // Core introspection
 // ---------------------------------------------------------------------------
@@ -184,7 +192,21 @@ export function shouldAutoRegisterWorktree(commandName: string | undefined): boo
     return true
   }
 
+  if (shouldSkipEarlyWork(commandName)) {
+    return false
+  }
+
   return !NON_WORKTREE_COMMANDS.has(commandName)
+}
+
+/**
+ * Check whether startup-time work should be skipped before parsing the command.
+ *
+ * Keep this as the single gate for any logic that runs before
+ * `program.parseAsync()` so new callers do not reintroduce early startup work.
+ */
+export function shouldSkipEarlyWork(commandName: string | undefined): boolean {
+  return commandName != null && SKIP_EARLY_WORK_COMMANDS.has(commandName)
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- Consolidated the early startup skip logic so `enter`, `completion`, and `shell-hook` no longer trigger pre-parse work.
- Reused the shared gate for both auto-registration and branch-collision warnings to keep startup behavior consistent.
## Testing
- `bunx vitest run src/lib/commands.test.ts`
- `bunx vitest run src/lib/commands.test.ts tests/completion.test.ts tests/shell-integration.test.ts`
- `bunx eslint src/index.ts src/lib/commands.ts src/lib/commands.test.ts`
## Risks
- None noted.
- `bunx tsc --noEmit` still reports an unrelated existing error in `src/commands/prune.ts`.