### PR TITLE
Unref readiness probe sockets (fix hanging issue)

### DIFF
--- a/src/lib/compose.test.ts
+++ b/src/lib/compose.test.ts
@@ -2,16 +2,24 @@ import { mkdtempSync } from 'fs'
 import { mkdir, readFile, rm, writeFile } from 'fs/promises'
 import { tmpdir } from 'os'
 import { join } from 'path'
-import { afterEach, beforeEach, describe, expect, test } from 'vitest'
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest'
 import {
   generateOverrideContent,
   getComposeFileStack,
   getServicePorts,
+  startTraefik,
   resolveComposeServices,
   renderPortVariables,
   renderUserOverrideFile,
 } from './compose.ts'
+import * as execModule from './exec.ts'
 import type { ParsedComposeFile } from '../types.ts'
+
+const netMock = vi.hoisted(() => ({
+  createConnection: vi.fn(),
+}))
+
+vi.mock('net', () => netMock)
 
 function createTempDir(): string {
   return mkdtempSync(join(tmpdir(), 'port-compose-test-'))
@@ -356,5 +364,35 @@ describe('renderUserOverrideFile', () => {
     })
 
     expect(renderedRelativePath).toBeNull()
+  })
+})
+
+describe('startTraefik', () => {
+  afterEach(() => {
+    vi.restoreAllMocks()
+    netMock.createConnection.mockReset()
+  })
+
+  test('unrefs readiness probe sockets before waiting for close', async () => {
+    vi.spyOn(execModule, 'execAsync').mockResolvedValue({ stdout: '', stderr: '' } as never)
+
+    const socket = {
+      destroy: vi.fn(),
+      unref: vi.fn(),
+      once(event: string, handler: () => void) {
+        if (event === 'connect') {
+          setImmediate(handler)
+        }
+
+        return this
+      },
+    }
+
+    netMock.createConnection.mockReturnValue(socket)
+
+    await startTraefik()
+
+    expect(socket.unref).toHaveBeenCalled()
+    expect(socket.destroy).toHaveBeenCalled()
   })
 })

--- a/src/lib/compose.ts
+++ b/src/lib/compose.ts
@@ -789,6 +789,7 @@ async function waitForTraefikReady(timeoutMs = 15000): Promise<void> {
   while (Date.now() - startTime < timeoutMs) {
     const connected = await new Promise<boolean>(resolve => {
       const socket = createConnection({ host: '127.0.0.1', port: 80 })
+      socket.unref?.()
       const timer = setTimeout(() => {
         socket.destroy()
         resolve(false)


### PR DESCRIPTION
## Summary
- Prevent Traefik readiness probes from keeping the event loop alive after `port` starts docker-backed commands.
- Add a regression test covering the socket cleanup behavior.
## Testing
- `bunx vitest run src/lib/compose.test.ts src/commands/compose.test.ts src/commands/up.test.ts src/commands/down.test.ts`
- `bunx tsc --noEmit`
## Risks
- Minimal: change is limited to Traefik readiness probing.
- If a probe fails unexpectedly, the existing retry loop still handles readiness as before.