### PR TITLE
Normalize uppercase Docker project names

### DIFF
--- a/src/lib/compose.test.ts
+++ b/src/lib/compose.test.ts
@@ -5,6 +5,7 @@ import { join } from 'path'
 import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest'
 import {
   generateOverrideContent,
+  getProjectName,
   getComposeFileStack,
   getServicePorts,
   startTraefik,
@@ -35,6 +36,16 @@ describe('getServicePorts', () => {
     })
 
     expect(ports).toEqual([18000, 3001])
+  })
+})
+
+describe('getProjectName', () => {
+  test('normalizes uppercase letters in worktree names for docker compose', () => {
+    expect(getProjectName('/repo', 'localStorage')).toBe('repo-localstorage')
+  })
+
+  test('returns the normalized repo name for the main repo', () => {
+    expect(getProjectName('/Users/jacob/Documents/GitHub/Port', 'Port')).toBe('port')
   })
 })
 

--- a/src/lib/compose.ts
+++ b/src/lib/compose.ts
@@ -5,7 +5,7 @@ import { stringify as yamlStringify } from 'yaml'
 import type { ParsedComposeFile, ParsedComposeService } from '../types.ts'
 import { TRAEFIK_NETWORK, TRAEFIK_DIR } from './traefik.ts'
 import { execAsync, execWithStdio } from './exec.ts'
-import { sanitizeFolderName } from './sanitize.ts'
+import { sanitizeBranchName, sanitizeFolderName } from './sanitize.ts'
 
 /**
  * Escape a shell argument to prevent command injection.
@@ -53,11 +53,12 @@ interface ComposeRuntimeContext {
  */
 export function getProjectName(repoRoot: string, worktreeName: string): string {
   const repoName = sanitizeFolderName(basename(repoRoot))
+  const sanitizedWorktreeName = sanitizeBranchName(worktreeName)
   // If worktree name is already the repo name (main repo case), just use it
-  if (repoName === worktreeName) {
-    return worktreeName
+  if (repoName === sanitizedWorktreeName) {
+    return repoName
   }
-  return `${repoName}-${worktreeName}`
+  return `${repoName}-${sanitizedWorktreeName}`
 }
 
 /**


### PR DESCRIPTION
## Summary
- Normalized Docker Compose project names so worktree names with uppercase letters no longer break `port up`.
- Added regression coverage for `getProjectName()` to ensure both worktree and main-repo names stay Docker-safe.
## Testing
- Ran `bunx vitest run src/lib/compose.test.ts`
- Ran `bunx vitest run src/commands/up.command.test.ts`
- Result: both passed
## Risks
- None noted.
- Behavior changes only affect Compose project naming; existing service routing and override generation remain unchanged.
_(Drafted by Jacob's coding agent on his behalf)_