### PR TITLE
Increase CI shards to 4

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,5 +48,5 @@ jobs:
     uses: ./.github/workflows/linux-integration-tests.yml
     with:
       run-traefik-diagnostics: true
-      shards: '[1,2,3]'
-      total-shards: 3
+      shards: '[1,2,3,4]'
+      total-shards: 4

--- a/.github/workflows/linux-integration-tests.yml
+++ b/.github/workflows/linux-integration-tests.yml
@@ -12,12 +12,12 @@ on:
         description: JSON array of shard indexes (for matrix)
         required: false
         type: string
-        default: '[1,2,3]'
+        default: '[1,2,3,4]'
       total-shards:
         description: Total number of Vitest shards
         required: false
         type: number
-        default: 3
+        default: 4
 
 jobs:
   linux-integration:

--- a/README.md
+++ b/README.md
@@ -586,9 +586,10 @@ bun run lint
 bun run test
 
 # Run a single integration shard (matches CI sharding)
-bunx vitest --shard=1/3
-bunx vitest --shard=2/3
-bunx vitest --shard=3/3
+bunx vitest --shard=1/4
+bunx vitest --shard=2/4
+bunx vitest --shard=3/4
+bunx vitest --shard=4/4
 ```
 
 ### Testing in Ubuntu Container


### PR DESCRIPTION
## Summary
- Increased Linux integration test fan-out from 3 shards to 4 in CI and the reusable workflow defaults.
- Updated the README integration shard examples to match the new 1/4 through 4/4 split.

## Testing
- Ran `bunx prettier --check` on the updated workflow and README files.
- Verified no stale 3-shard references remained in the touched docs/workflow files.

## Risks
- CI runtime and shard balance will change because tests are now distributed across four shards instead of three.
- README examples and workflow defaults should stay in sync if shard count changes again.

_(Drafted by Jacob's coding agent on his behalf)_
