### PR TITLE
Port rename command

### DIFF
--- a/ONBOARD.md
+++ b/ONBOARD.md
@@ -56,7 +56,12 @@ Port is a CLI for managing git worktrees that makes it easy to create, enter, an
 - **How**: Run to return to the repository root from a worktree.
 - **Why**: Changes back to the repo root and clears PORT_WORKTREE env var.
 
-### 11. `port remove <branch>`
+### 11. `port rename <branch>`
+
+- **How**: Run inside a worktree after stopping its services. Alias: port mv <branch>.
+- **Why**: Renames the current worktree and branch while keeping Port state aligned.
+
+### 12. `port remove <branch>`
 
 - **How**: Use after a branch is done.
 - **Why**: Stops services, removes worktree, and archives the local branch.

--- a/README.md
+++ b/README.md
@@ -163,7 +163,17 @@ port exit
 
 Returns to the repository root and clears the `PORT_WORKTREE` environment variable.
 
-### 8. Start Services
+### 8. Rename a Worktree
+
+```bash
+port rename feature-new
+# or use the shorthand
+port mv feature-new
+```
+
+Run this from inside the worktree after stopping its services. It renames the current worktree and branch in place and keeps Port state aligned.
+
+### 9. Start Services
 
 ```bash
 port up [services...]
@@ -180,7 +190,7 @@ rerun that hook with:
 port open
 ```
 
-### 9. Stop Services
+### 10. Stop Services
 
 ```bash
 port down [services...]
@@ -188,7 +198,7 @@ port down [services...]
 
 Stops all services by default, or a selected subset when service names are provided. The selected containers are removed without tearing down the whole worktree.
 
-### 10. Run Host Processes (Non-Docker)
+### 11. Run Host Processes (Non-Docker)
 
 ```bash
 port run 3000 -- npm run dev
@@ -202,7 +212,7 @@ This is useful for:
 - Quick testing without containerization
 - Running multiple instances of the same service on different worktrees
 
-### 11. Check Status
+### 12. Check Status
 
 ```bash
 port status
@@ -219,7 +229,7 @@ port urls ui-frontend
 
 `port urls` works in either a worktree or the main repository.
 
-### 12. Remove a Worktree
+### 13. Remove a Worktree
 
 ```bash
 port remove feature-1
@@ -241,7 +251,7 @@ Use `--keep-branch` to preserve the local branch name.
 - Use `--cleanup-images` to clean up images without prompting
 - Image cleanup is opt-in to prevent accidentally removing shared base images
 
-### 13. Clean Up Archived Branches
+### 14. Clean Up Archived Branches
 
 ```bash
 port cleanup
@@ -270,6 +280,7 @@ Shows archived branches created by `port remove` and asks for confirmation befor
 | `port enter <branch>`                                               | Enter a worktree explicitly (including command names)           |
 | `port <branch>`                                                     | Enter a worktree (creates if doesn't exist)                     |
 | `port exit`                                                         | Exit the current worktree and return to repo root               |
+| `port rename <branch>` / `port mv <branch>`                         | Rename the current worktree and branch in place                 |
 | `port up [services...]`                                             | Start docker-compose services in current worktree               |
 | `port open`                                                         | Re-run the `post-up` hook in the current repo/worktree context  |
 | `port down [services...]`                                           | Stop docker-compose services and host processes selectively     |

--- a/src/commands/__snapshots__/onboard.test.ts.snap
+++ b/src/commands/__snapshots__/onboard.test.ts.snap
@@ -59,7 +59,12 @@ Port is a CLI for managing git worktrees that makes it easy to create, enter, an
 - **How**: Run to return to the repository root from a worktree.
 - **Why**: Changes back to the repo root and clears PORT_WORKTREE env var.
 
-### 11. \`port remove <branch>\`
+### 11. \`port rename <branch>\`
+
+- **How**: Run inside a worktree after stopping its services. Alias: port mv <branch>.
+- **Why**: Renames the current worktree and branch while keeping Port state aligned.
+
+### 12. \`port remove <branch>\`
 
 - **How**: Use after a branch is done.
 - **Why**: Stops services, removes worktree, and archives the local branch.
@@ -138,7 +143,12 @@ Port is a CLI for managing git worktrees that makes it easy to create, enter, an
 - **How**: Run to return to the repository root from a worktree.
 - **Why**: Changes back to the repo root and clears PORT_WORKTREE env var.
 
-### 11. \`port remove <branch>\`
+### 11. \`port rename <branch>\`
+
+- **How**: Run inside a worktree after stopping its services. Alias: port mv <branch>.
+- **Why**: Renames the current worktree and branch while keeping Port state aligned.
+
+### 12. \`port remove <branch>\`
 
 - **How**: Use after a branch is done.
 - **Why**: Stops services, removes worktree, and archives the local branch.

--- a/src/commands/onboard.test.ts
+++ b/src/commands/onboard.test.ts
@@ -54,6 +54,7 @@ describe('onboard command', () => {
     expect(mocks.header).toHaveBeenCalledWith('3. port shell-hook <bash|zsh|fish>')
     expect(mocks.header).toHaveBeenCalledWith('4. port enter <branch>')
     expect(mocks.header).toHaveBeenCalledWith('6. port open')
+    expect(mocks.header).toHaveBeenCalledWith('11. port rename <branch>')
     expect(mocks.header).toHaveBeenCalledWith(expect.stringContaining('port compose'))
     expect(mocks.header).toHaveBeenCalledWith(expect.stringContaining('port completion'))
     expect(mocks.header).toHaveBeenCalledWith(expect.stringContaining('port exit'))

--- a/src/commands/onboard.ts
+++ b/src/commands/onboard.ts
@@ -61,6 +61,11 @@ const STEPS: OnboardStep[] = [
     why: 'Changes back to the repo root and clears PORT_WORKTREE env var.',
   },
   {
+    command: 'port rename <branch>',
+    how: 'Run inside a worktree after stopping its services. Alias: port mv <branch>.',
+    why: 'Renames the current worktree and branch while keeping Port state aligned.',
+  },
+  {
     command: 'port remove <branch>',
     how: 'Use after a branch is done.',
     why: 'Stops services, removes worktree, and archives the local branch.',

--- a/src/commands/rename.command.test.ts
+++ b/src/commands/rename.command.test.ts
@@ -1,0 +1,17 @@
+import { describe, expect, test, vi } from 'vitest'
+
+const mocks = vi.hoisted(() => ({
+  rename: vi.fn(),
+}))
+
+vi.mock('./rename.ts', () => ({
+  rename: mocks.rename,
+}))
+
+import { rename as renameCommand } from './rename.ts'
+
+describe('rename command registration', () => {
+  test('exports the rename command implementation', () => {
+    expect(renameCommand).toBeTypeOf('function')
+  })
+})

--- a/src/commands/rename.test.ts
+++ b/src/commands/rename.test.ts
@@ -1,0 +1,141 @@
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest'
+
+const mocks = vi.hoisted(() => ({
+  detectWorktree: vi.fn(),
+  ensurePortRuntimeDir: vi.fn(),
+  loadConfigOrDefault: vi.fn(),
+  getComposeFile: vi.fn(),
+  worktreeExists: vi.fn(),
+  getWorktreePath: vi.fn(),
+  renameWorktree: vi.fn(),
+  getCurrentBranch: vi.fn(),
+  branchExists: vi.fn(),
+  branchHasRunningServices: vi.fn(),
+  rewriteRegistryForRename: vi.fn(),
+  rewriteHostServicesForRename: vi.fn(),
+  parseComposeFile: vi.fn(),
+  writeOverrideFile: vi.fn(),
+  getProjectName: vi.fn(),
+  success: vi.fn(),
+  warn: vi.fn(),
+  error: vi.fn(),
+  info: vi.fn(),
+  dim: vi.fn(),
+  newline: vi.fn(),
+  branch: vi.fn(),
+}))
+
+vi.mock('../lib/worktree.ts', () => ({
+  detectWorktree: mocks.detectWorktree,
+  worktreeExists: mocks.worktreeExists,
+  getWorktreePath: mocks.getWorktreePath,
+}))
+
+vi.mock('../lib/config.ts', () => ({
+  ensurePortRuntimeDir: mocks.ensurePortRuntimeDir,
+  loadConfigOrDefault: mocks.loadConfigOrDefault,
+  getComposeFile: mocks.getComposeFile,
+}))
+
+vi.mock('../lib/git.ts', () => ({
+  getCurrentBranch: mocks.getCurrentBranch,
+  branchExists: mocks.branchExists,
+  renameWorktree: mocks.renameWorktree,
+}))
+
+vi.mock('../lib/registry.ts', () => ({
+  rewriteRegistryForRename: mocks.rewriteRegistryForRename,
+  branchHasRunningServices: mocks.branchHasRunningServices,
+  rewriteHostServicesForRename: mocks.rewriteHostServicesForRename,
+}))
+
+vi.mock('../lib/compose.ts', () => ({
+  parseComposeFile: mocks.parseComposeFile,
+  writeOverrideFile: mocks.writeOverrideFile,
+  getProjectName: mocks.getProjectName,
+}))
+
+vi.mock('../lib/output.ts', () => ({
+  success: mocks.success,
+  warn: mocks.warn,
+  error: mocks.error,
+  info: mocks.info,
+  dim: mocks.dim,
+  newline: mocks.newline,
+  branch: mocks.branch,
+}))
+
+import { rename } from './rename.ts'
+
+describe('rename command', () => {
+  const originalArgv = process.argv
+  let exitSpy: ReturnType<typeof vi.spyOn>
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+
+    mocks.detectWorktree.mockReturnValue({
+      repoRoot: '/repo',
+      worktreePath: '/repo/.port/trees/feature-old',
+      name: 'feature-old',
+      isMainRepo: false,
+    })
+    mocks.ensurePortRuntimeDir.mockResolvedValue(undefined)
+    mocks.loadConfigOrDefault.mockResolvedValue({ domain: 'port', compose: 'docker-compose.yml' })
+    mocks.getComposeFile.mockReturnValue('docker-compose.yml')
+    mocks.worktreeExists.mockReturnValue(true)
+    mocks.worktreeExists.mockReturnValueOnce(false)
+    mocks.getWorktreePath.mockReturnValue('/repo/.port/trees/feature-new')
+    mocks.getCurrentBranch.mockResolvedValue('feature-old')
+    mocks.branchExists.mockResolvedValue(false)
+    mocks.branchHasRunningServices.mockResolvedValue(false)
+    mocks.renameWorktree.mockResolvedValue('/repo/.port/trees/feature-new')
+    mocks.rewriteRegistryForRename.mockResolvedValue(undefined)
+    mocks.rewriteHostServicesForRename.mockResolvedValue(undefined)
+    mocks.parseComposeFile.mockResolvedValue({ name: 'repo', services: {} })
+    mocks.writeOverrideFile.mockResolvedValue(undefined)
+    mocks.getProjectName.mockReturnValue('repo-feature-new')
+    mocks.branch.mockImplementation((value: string) => value)
+
+    process.argv = ['/usr/local/bin/bun', '/repo/dist/index.js', 'rename', 'feature-new']
+
+    exitSpy = vi.spyOn(process, 'exit').mockImplementation((code?: string | number | null) => {
+      throw new Error(`process.exit:${typeof code === 'number' ? code : 0}`)
+    })
+  })
+
+  afterEach(() => {
+    process.argv = originalArgv
+    exitSpy.mockRestore()
+  })
+
+  test('refuses to rename when running services are detected', async () => {
+    mocks.branchHasRunningServices.mockResolvedValue(true)
+
+    await expect(rename('feature-new')).rejects.toThrow(
+      'Stop running services before renaming this worktree.'
+    )
+
+    expect(mocks.info).toHaveBeenCalledWith('Checking for running services...')
+    expect(mocks.error).toHaveBeenCalledWith(
+      'Stop running services before renaming this worktree.'
+    )
+    expect(mocks.renameWorktree).not.toHaveBeenCalled()
+  })
+
+  test('renames the current worktree and refreshes Port state', async () => {
+    await rename('feature-new')
+
+    expect(mocks.renameWorktree).toHaveBeenCalledWith('/repo', 'feature-old', 'feature-new')
+    expect(mocks.rewriteRegistryForRename).toHaveBeenCalledWith('/repo', 'feature-old', 'feature-new')
+    expect(mocks.rewriteHostServicesForRename).toHaveBeenCalledWith('/repo', 'feature-old', 'feature-new')
+    expect(mocks.writeOverrideFile).toHaveBeenCalledWith(
+      '/repo/.port/trees/feature-new',
+      expect.any(Object),
+      'feature-new',
+      'port',
+      'repo-feature-new'
+    )
+    expect(mocks.success).toHaveBeenCalledWith('Renamed worktree feature-old → feature-new')
+  })
+})

--- a/src/commands/rename.test.ts
+++ b/src/commands/rename.test.ts
@@ -117,9 +117,7 @@ describe('rename command', () => {
     )
 
     expect(mocks.info).toHaveBeenCalledWith('Checking for running services...')
-    expect(mocks.error).toHaveBeenCalledWith(
-      'Stop running services before renaming this worktree.'
-    )
+    expect(mocks.error).toHaveBeenCalledWith('Stop running services before renaming this worktree.')
     expect(mocks.renameWorktree).not.toHaveBeenCalled()
   })
 
@@ -127,8 +125,16 @@ describe('rename command', () => {
     await rename('feature-new')
 
     expect(mocks.renameWorktree).toHaveBeenCalledWith('/repo', 'feature-old', 'feature-new')
-    expect(mocks.rewriteRegistryForRename).toHaveBeenCalledWith('/repo', 'feature-old', 'feature-new')
-    expect(mocks.rewriteHostServicesForRename).toHaveBeenCalledWith('/repo', 'feature-old', 'feature-new')
+    expect(mocks.rewriteRegistryForRename).toHaveBeenCalledWith(
+      '/repo',
+      'feature-old',
+      'feature-new'
+    )
+    expect(mocks.rewriteHostServicesForRename).toHaveBeenCalledWith(
+      '/repo',
+      'feature-old',
+      'feature-new'
+    )
     expect(mocks.writeOverrideFile).toHaveBeenCalledWith(
       '/repo/.port/trees/feature-new',
       expect.any(Object),

--- a/src/commands/rename.ts
+++ b/src/commands/rename.ts
@@ -80,11 +80,18 @@ export async function rename(newBranch: string): Promise<void> {
 
   const evalCtx = getEvalContext()
   if (evalCtx) {
-    const commands = buildEnterCommands(evalCtx.shell, newWorktreePath, sanitizedNewBranch, repoRoot)
+    const commands = buildEnterCommands(
+      evalCtx.shell,
+      newWorktreePath,
+      sanitizedNewBranch,
+      repoRoot
+    )
     writeEvalFile(commands, evalCtx.evalFile)
   } else {
     output.newline()
-    output.success(`Renamed worktree ${output.branch(oldWorktreeName)} → ${output.branch(sanitizedNewBranch)}`)
+    output.success(
+      `Renamed worktree ${output.branch(oldWorktreeName)} → ${output.branch(sanitizedNewBranch)}`
+    )
     output.newline()
     output.info(`Run: cd ${newWorktreePath}`)
   }

--- a/src/commands/rename.ts
+++ b/src/commands/rename.ts
@@ -1,0 +1,91 @@
+import { detectWorktree, worktreeExists } from '../lib/worktree.ts'
+import { ensurePortRuntimeDir, loadConfigOrDefault, getComposeFile } from '../lib/config.ts'
+import { getCurrentBranch, branchExists, renameWorktree } from '../lib/git.ts'
+import {
+  branchHasRunningServices,
+  rewriteRegistryForRename,
+  rewriteHostServicesForRename,
+} from '../lib/registry.ts'
+import { parseComposeFile, writeOverrideFile, getProjectName } from '../lib/compose.ts'
+import { sanitizeBranchName } from '../lib/sanitize.ts'
+import * as output from '../lib/output.ts'
+import { failWithError } from '../lib/cli.ts'
+import { buildEnterCommands, getEvalContext, writeEvalFile } from '../lib/shell.ts'
+
+/**
+ * Rename the current worktree and keep Port state aligned.
+ */
+export async function rename(newBranch: string): Promise<void> {
+  let worktreeInfo
+  try {
+    worktreeInfo = detectWorktree()
+  } catch {
+    failWithError('Not in a git repository')
+  }
+
+  if (worktreeInfo.isMainRepo) {
+    failWithError('Run `port rename` from inside a worktree.')
+  }
+
+  const repoRoot = worktreeInfo.repoRoot
+  await ensurePortRuntimeDir(repoRoot)
+
+  const config = await loadConfigOrDefault(repoRoot)
+  const composeFile = getComposeFile(config)
+  const oldBranch = await getCurrentBranch(worktreeInfo.worktreePath)
+  const oldWorktreeName = worktreeInfo.name
+  const sanitizedNewBranch = sanitizeBranchName(newBranch)
+
+  if (sanitizedNewBranch !== newBranch) {
+    output.dim(`Branch name sanitized: ${newBranch} → ${sanitizedNewBranch}`)
+  }
+
+  if (sanitizedNewBranch === oldWorktreeName && newBranch === oldBranch) {
+    output.info('Worktree already has that name')
+    return
+  }
+
+  output.info('Checking for running services...')
+
+  if (await branchHasRunningServices(repoRoot, oldWorktreeName, composeFile, config.domain)) {
+    failWithError('Stop running services before renaming this worktree.')
+  }
+
+  if (newBranch !== oldBranch && (await branchExists(repoRoot, newBranch))) {
+    failWithError(`Branch already exists: ${newBranch}`)
+  }
+
+  if (sanitizedNewBranch !== oldWorktreeName && worktreeExists(repoRoot, newBranch)) {
+    failWithError(`Worktree already exists: ${sanitizedNewBranch}`)
+  }
+
+  const newWorktreePath = await renameWorktree(repoRoot, oldBranch, newBranch)
+
+  await rewriteRegistryForRename(repoRoot, oldWorktreeName, sanitizedNewBranch)
+  await rewriteHostServicesForRename(repoRoot, oldWorktreeName, sanitizedNewBranch)
+
+  try {
+    const parsedCompose = await parseComposeFile(newWorktreePath, composeFile)
+    const projectName = getProjectName(repoRoot, sanitizedNewBranch)
+    await writeOverrideFile(
+      newWorktreePath,
+      parsedCompose,
+      sanitizedNewBranch,
+      config.domain,
+      projectName
+    )
+  } catch {
+    output.dim('Could not refresh .port/override.yml after rename')
+  }
+
+  const evalCtx = getEvalContext()
+  if (evalCtx) {
+    const commands = buildEnterCommands(evalCtx.shell, newWorktreePath, sanitizedNewBranch, repoRoot)
+    writeEvalFile(commands, evalCtx.evalFile)
+  } else {
+    output.newline()
+    output.success(`Renamed worktree ${output.branch(oldWorktreeName)} → ${output.branch(sanitizedNewBranch)}`)
+    output.newline()
+    output.info(`Run: cd ${newWorktreePath}`)
+  }
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -25,6 +25,7 @@ import { shellHook } from './commands/shell-hook.ts'
 import { completion } from './commands/completion.ts'
 import { hook } from './commands/hook.ts'
 import { open } from './commands/open.ts'
+import { rename } from './commands/rename.ts'
 import {
   isReservedCommand,
   shouldAutoRegisterWorktree,
@@ -241,6 +242,15 @@ program
   .command('open')
   .description('Run the post-up hook in the current repo/worktree context')
   .action(open)
+
+// port rename <branch>
+program
+  .command('rename <branch>')
+  .alias('mv')
+  .description('Rename the current worktree and branch')
+  .action(async (branch: string) => {
+    await rename(branch)
+  })
 
 // port completion <shell>
 program

--- a/src/lib/commands.test.ts
+++ b/src/lib/commands.test.ts
@@ -41,6 +41,7 @@ describe('getSubcommands', () => {
     const cmds = getSubcommands()
     expect(cmds).toContain('init')
     expect(cmds).toContain('enter')
+    expect(cmds).toContain('rename')
     expect(cmds).toContain('remove')
     expect(cmds).toContain('list')
     expect(cmds).toContain('status')
@@ -53,6 +54,7 @@ describe('getSubcommands', () => {
   test('includes aliases', () => {
     const cmds = getSubcommands()
     expect(cmds).toContain('ls')
+    expect(cmds).toContain('mv')
     expect(cmds).toContain('rm')
     expect(cmds).toContain('dc')
   })

--- a/src/lib/git.test.ts
+++ b/src/lib/git.test.ts
@@ -1,5 +1,18 @@
-import { describe, expect, test } from 'vitest'
-import { parseDuplicateWorktreeError } from './git.ts'
+import { describe, expect, test, vi } from 'vitest'
+
+const rawMock = vi.hoisted(() => vi.fn())
+
+vi.mock('simple-git', () => ({
+  default: vi.fn(() => ({
+    raw: rawMock,
+  })),
+}))
+
+vi.mock('./worktree.ts', () => ({
+  getWorktreePath: vi.fn((repoRoot: string, branch: string) => `${repoRoot}/.port/trees/${branch}`),
+}))
+
+import { parseDuplicateWorktreeError, renameWorktree } from './git.ts'
 
 describe('parseDuplicateWorktreeError', () => {
   test('extracts branch and path from duplicate-worktree output', () => {
@@ -15,5 +28,19 @@ describe('parseDuplicateWorktreeError', () => {
 
   test('returns null for unrelated failures', () => {
     expect(parseDuplicateWorktreeError(new Error('fatal: unrelated failure'))).toBeNull()
+  })
+})
+
+describe('renameWorktree', () => {
+  test('moves the worktree path and renames the branch ref', async () => {
+    await renameWorktree('/repo', 'feature-old', 'feature-new')
+
+    expect(rawMock).toHaveBeenNthCalledWith(1, ['branch', '-m', 'feature-old', 'feature-new'])
+    expect(rawMock).toHaveBeenNthCalledWith(2, [
+      'worktree',
+      'move',
+      '/repo/.port/trees/feature-old',
+      '/repo/.port/trees/feature-new',
+    ])
   })
 })

--- a/src/lib/git.ts
+++ b/src/lib/git.ts
@@ -202,6 +202,34 @@ export async function createWorktree(repoRoot: string, branch: string): Promise<
 }
 
 /**
+ * Rename the current worktree to a new branch/path.
+ *
+ * Uses `git branch -m` for the branch ref and `git worktree move` for the
+ * on-disk worktree path so Git's worktree metadata stays consistent.
+ */
+export async function renameWorktree(
+  repoRoot: string,
+  oldBranch: string,
+  newBranch: string
+): Promise<string> {
+  const git = getGit(repoRoot)
+  const oldPath = getWorktreePath(repoRoot, oldBranch)
+  const newPath = getWorktreePath(repoRoot, newBranch)
+
+  try {
+    await git.raw(['branch', '-m', oldBranch, newBranch])
+
+    if (oldPath !== newPath) {
+      await git.raw(['worktree', 'move', oldPath, newPath])
+    }
+
+    return newPath
+  } catch (error) {
+    throw new GitError(`Failed to rename worktree '${oldBranch}' to '${newBranch}': ${error}`)
+  }
+}
+
+/**
  * Remove a worktree
  *
  * @param repoRoot - The repository root path

--- a/src/lib/registry.test.ts
+++ b/src/lib/registry.test.ts
@@ -2,6 +2,10 @@ import { test, expect, describe, beforeAll, beforeEach } from 'vitest'
 import { dirname } from 'path'
 import type { HostService } from '../types.ts'
 import { useIsolatedPortGlobalDir } from '@tests/isolatedGlobalDir'
+import { mkdtempSync, existsSync } from 'fs'
+import { join } from 'path'
+import { tmpdir } from 'os'
+import { writeFile, readFile } from 'fs/promises'
 
 type RegistryModule = typeof import('./registry.ts')
 
@@ -137,6 +141,70 @@ describe('Host Service Registry Functions', () => {
       expect(projects.map(project => project.branch).sort()).toEqual(
         Array.from({ length: 20 }, (_, index) => `branch-${index}`).sort()
       )
+    })
+  })
+
+  describe('rewriteRegistryForRename', () => {
+    test('updates matching project branches', async () => {
+      await registry.registerProject('/test/repo', 'old-name', [3000])
+      await registry.registerProject('/test/repo', 'other-name', [3001])
+
+      await registry.rewriteRegistryForRename('/test/repo', 'old-name', 'new-name')
+
+      expect(await registry.getAllProjects()).toEqual([
+        { repo: '/test/repo', branch: 'new-name', ports: [3000] },
+        { repo: '/test/repo', branch: 'other-name', ports: [3001] },
+      ])
+    })
+  })
+
+  describe('rewriteHostServicesForRename', () => {
+    test('renames config files and updates registry entries', async () => {
+      const tempDir = mkdtempSync(join(tmpdir(), 'port-rename-host-'))
+      const oldConfigFile = join(tempDir, 'old-name-3000.yml')
+      const newConfigFile = join(tempDir, 'new-name-3000.yml')
+
+      await writeFile(
+        oldConfigFile,
+        'http:\n  routers:\n    old-name-3000:\n      rule: Host(`old-name.port`)\n'
+      )
+
+      await registry.registerHostService({
+        repo: '/test/repo',
+        branch: 'old-name',
+        logicalPort: 3000,
+        actualPort: 49152,
+        pid: 12345,
+        configFile: oldConfigFile,
+      })
+
+      await registry.rewriteHostServicesForRename('/test/repo', 'old-name', 'new-name')
+
+      expect(existsSync(oldConfigFile)).toBe(false)
+      expect(existsSync(newConfigFile)).toBe(true)
+      expect(await readFile(newConfigFile, 'utf-8')).toContain('new-name.port')
+
+      expect(await registry.getHostService('/test/repo', 'new-name', 3000)).toMatchObject({
+        branch: 'new-name',
+        configFile: newConfigFile,
+      })
+    })
+  })
+
+  describe('branchHasRunningServices', () => {
+    test('returns true when a registered host service process is alive', async () => {
+      await registry.registerHostService({
+        repo: '/test/repo',
+        branch: 'old-name',
+        logicalPort: 3000,
+        actualPort: 49152,
+        pid: process.pid,
+        configFile: '/tmp/old-name-3000.yml',
+      })
+
+      await expect(
+        registry.branchHasRunningServices('/test/repo', 'old-name', 'missing-compose.yml', 'port')
+      ).resolves.toBe(true)
     })
   })
 

--- a/src/lib/registry.ts
+++ b/src/lib/registry.ts
@@ -1,9 +1,11 @@
-import { readFile, mkdir } from 'fs/promises'
+import { readFile, mkdir, rename, writeFile } from 'fs/promises'
 import { existsSync } from 'fs'
 import { join } from 'path'
 import { homedir } from 'os'
 import type { Registry, Project, HostService, RunningWorktreeNames } from '../types.ts'
 import { withFileLock, writeFileAtomic } from './state.ts'
+import { getWorktreePath } from './worktree.ts'
+import { sanitizeBranchName } from './sanitize.ts'
 
 /** Optional env var to override global state directory (used by tests) */
 const GLOBAL_PORT_DIR_ENV = 'PORT_GLOBAL_DIR'
@@ -68,11 +70,11 @@ export async function saveRegistry(registry: Registry): Promise<void> {
   await writeFileAtomic(REGISTRY_FILE, JSON.stringify(registry, null, 2))
 }
 
-async function mutateRegistry(mutator: (registry: Registry) => void): Promise<void> {
+async function mutateRegistry(mutator: (registry: Registry) => void | Promise<void>): Promise<void> {
   await ensureGlobalDir()
   await withFileLock(REGISTRY_LOCK_FILE, async () => {
     const registry = await loadRegistry()
-    mutator(registry)
+    await mutator(registry)
     await saveRegistry(registry)
   })
 }
@@ -109,6 +111,23 @@ export async function registerProject(
 export async function unregisterProject(repo: string, branch: string): Promise<void> {
   await mutateRegistry(registry => {
     registry.projects = registry.projects.filter(p => !(p.repo === repo && p.branch === branch))
+  })
+}
+
+/**
+ * Update registered projects when a worktree is renamed.
+ */
+export async function rewriteRegistryForRename(
+  repo: string,
+  oldBranch: string,
+  newBranch: string
+): Promise<void> {
+  await mutateRegistry(registry => {
+    for (const project of registry.projects) {
+      if (project.repo === repo && project.branch === oldBranch) {
+        project.branch = newBranch
+      }
+    }
   })
 }
 
@@ -269,6 +288,79 @@ export async function getHostServicesForWorktree(
 ): Promise<HostService[]> {
   const registry = await loadRegistry()
   return registry.hostServices?.filter(s => s.repo === repo && s.branch === branch) ?? []
+}
+
+function isProcessRunning(pid: number): boolean {
+  try {
+    process.kill(pid, 0)
+    return true
+  } catch {
+    return false
+  }
+}
+
+/**
+ * Check whether the current worktree still has running Docker or host services.
+ */
+export async function branchHasRunningServices(
+  repo: string,
+  branch: string,
+  composeFile: string,
+  domain: string
+): Promise<boolean> {
+  const worktreePath = getWorktreePath(repo, branch)
+
+  try {
+    const { composePs, getProjectName } = await import('./compose.ts')
+    const status = await composePs(worktreePath, composeFile, getProjectName(repo, branch), {
+      repoRoot: repo,
+      branch: sanitizeBranchName(branch),
+      domain,
+    })
+
+    if (status.some(service => service.running)) {
+      return true
+    }
+  } catch {
+    // Best effort only.
+  }
+
+  const registry = await loadRegistry()
+  return (registry.hostServices ?? []).some(
+    service => service.repo === repo && service.branch === branch && isProcessRunning(service.pid)
+  )
+}
+
+/**
+ * Update host service config files and registry entries for a renamed worktree.
+ */
+export async function rewriteHostServicesForRename(
+  repo: string,
+  oldBranch: string,
+  newBranch: string
+): Promise<void> {
+  await mutateRegistry(async registry => {
+    const matches = (registry.hostServices ?? []).filter(
+      service => service.repo === repo && service.branch === oldBranch
+    )
+
+    for (const service of matches) {
+      const oldFile = service.configFile
+      const newFile = oldFile.replace(oldBranch, newBranch)
+
+      if (oldFile !== newFile && existsSync(oldFile)) {
+        await rename(oldFile, newFile)
+      }
+
+      if (existsSync(newFile)) {
+        const content = await readFile(newFile, 'utf-8')
+        await writeFile(newFile, content.replaceAll(oldBranch, newBranch))
+      }
+
+      service.branch = newBranch
+      service.configFile = newFile
+    }
+  })
 }
 
 /**

--- a/src/lib/registry.ts
+++ b/src/lib/registry.ts
@@ -70,7 +70,9 @@ export async function saveRegistry(registry: Registry): Promise<void> {
   await writeFileAtomic(REGISTRY_FILE, JSON.stringify(registry, null, 2))
 }
 
-async function mutateRegistry(mutator: (registry: Registry) => void | Promise<void>): Promise<void> {
+async function mutateRegistry(
+  mutator: (registry: Registry) => void | Promise<void>
+): Promise<void> {
   await ensureGlobalDir()
   await withFileLock(REGISTRY_LOCK_FILE, async () => {
     const registry = await loadRegistry()

--- a/tests/rename.test.ts
+++ b/tests/rename.test.ts
@@ -1,0 +1,154 @@
+import { execSync } from 'child_process'
+import { mkdtempSync, writeFileSync, chmodSync, realpathSync, existsSync } from 'fs'
+import { rm } from 'fs/promises'
+import { join, resolve } from 'path'
+import { tmpdir } from 'os'
+import { afterAll, beforeAll, describe, test, expect } from 'vitest'
+import { execPortAsync, prepareSample } from './utils'
+import { execAsync } from '../src/lib/exec'
+
+const TIMEOUT = 60_000
+const CLI_ENTRY = resolve(__dirname, '../src/index.ts')
+
+/**
+ * Parse structured KEY=VALUE lines from shell output.
+ */
+function parseOutput(output: string): Record<string, string> {
+  const vars: Record<string, string> = {}
+  for (const line of output.split('\n')) {
+    const match = line.match(/^([A-Z_]+)=(.*)$/)
+    if (match && match[1] && match[2] !== undefined) {
+      vars[match[1]] = match[2]
+    }
+  }
+  return vars
+}
+
+describe('port rename', () => {
+  test(
+    'renames the current worktree directory and branch in place',
+    async () => {
+      const sample = await prepareSample('simple-server', {
+        initWithConfig: true,
+      })
+
+      try {
+        // 1. Create a worktree to rename
+        await execPortAsync(['enter', 'rename-old'], sample.dir)
+        const oldPath = join(sample.dir, '.port/trees/rename-old')
+        const newPath = join(sample.dir, '.port/trees/rename-new')
+        expect(existsSync(oldPath)).toBe(true)
+
+        // 2. Rename it from inside the worktree
+        await execPortAsync(['rename', 'rename-new'], oldPath)
+
+        // 3. The on-disk worktree moved to the new name
+        expect(existsSync(newPath)).toBe(true)
+        expect(existsSync(oldPath)).toBe(false)
+
+        // 4. The branch ref was renamed (old gone, new present)
+        const { stdout } = await execAsync('git branch --list', { cwd: sample.dir })
+        const branches = stdout
+          .split('\n')
+          .map(line => line.replace(/^[*+]?\s+/, '').trim())
+          .filter(Boolean)
+        expect(branches).toContain('rename-new')
+        expect(branches).not.toContain('rename-old')
+
+        // 5. The moved worktree still points at the renamed branch
+        const { stdout: headBranch } = await execAsync('git rev-parse --abbrev-ref HEAD', {
+          cwd: newPath,
+        })
+        expect(headBranch.trim()).toBe('rename-new')
+      } finally {
+        await sample.cleanup()
+      }
+    },
+    TIMEOUT
+  )
+
+  test(
+    'supports the mv alias',
+    async () => {
+      const sample = await prepareSample('simple-server', {
+        initWithConfig: true,
+      })
+
+      try {
+        await execPortAsync(['enter', 'mv-old'], sample.dir)
+        const oldPath = join(sample.dir, '.port/trees/mv-old')
+        const newPath = join(sample.dir, '.port/trees/mv-new')
+        expect(existsSync(oldPath)).toBe(true)
+
+        await execPortAsync(['mv', 'mv-new'], oldPath)
+
+        expect(existsSync(newPath)).toBe(true)
+        expect(existsSync(oldPath)).toBe(false)
+      } finally {
+        await sample.cleanup()
+      }
+    },
+    TIMEOUT
+  )
+
+  describe('shell integration', () => {
+    let portBinDir: string
+    let env: NodeJS.ProcessEnv
+
+    beforeAll(() => {
+      portBinDir = mkdtempSync(join(tmpdir(), 'port-bin-'))
+      const portScript = join(portBinDir, 'port')
+      writeFileSync(portScript, `#!/usr/bin/env bash\nexec bun "${CLI_ENTRY}" "$@"\n`)
+      chmodSync(portScript, 0o755)
+      env = { ...process.env, PATH: `${portBinDir}:${process.env.PATH}` }
+    })
+
+    afterAll(async () => {
+      await rm(portBinDir, { recursive: true, force: true })
+    })
+
+    test(
+      'shell hook updates cwd and PORT_WORKTREE after rename',
+      async () => {
+        const sample = await prepareSample('simple-server', {
+          initWithConfig: true,
+        })
+        const sampleDir = realpathSync(sample.dir)
+
+        try {
+          const result = execSync(
+            `bash -c '
+              eval "$(port shell-hook bash)"
+              cd "${sampleDir}"
+              port enter rename-shell-old
+              echo "ENTER_PWD=$PWD"
+              echo "ENTER_WORKTREE=$PORT_WORKTREE"
+              port rename rename-shell-new
+              echo "RENAME_PWD=$PWD"
+              echo "RENAME_WORKTREE=\${PORT_WORKTREE:-}"
+            '`,
+            { encoding: 'utf-8', env, timeout: TIMEOUT }
+          )
+
+          const vars = parseOutput(result)
+
+          // After enter, should be inside the original worktree
+          expect(vars.ENTER_PWD).toContain('.port/trees/rename-shell-old')
+          expect(vars.ENTER_WORKTREE).toBe('rename-shell-old')
+
+          // After rename, cwd follows the moved worktree and env reflects the new name
+          expect(vars.RENAME_PWD).toContain('.port/trees/rename-shell-new')
+          expect(vars.RENAME_PWD).not.toContain('rename-shell-old')
+          expect(vars.RENAME_WORKTREE).toBe('rename-shell-new')
+
+          // On-disk state matches: new dir exists, old is gone
+          expect(existsSync(join(sampleDir, '.port/trees/rename-shell-new'))).toBe(true)
+          expect(existsSync(join(sampleDir, '.port/trees/rename-shell-old'))).toBe(false)
+        } finally {
+          await sample.cleanup()
+        }
+      },
+      TIMEOUT
+    )
+  })
+})


### PR DESCRIPTION
## Summary
- Added `port rename` with `port mv` as a shorthand to rename the current worktree in place.
- Renaming now refuses to proceed while Docker or host services are running, and keeps Port state aligned by updating registry entries, host-service config, and generated override files.
- Updated onboarding and README docs to surface the new workflow.
## Testing
- Ran focused Vitest coverage for rename, git, registry, commands, and onboarding changes.
- Ran `bunx tsc --noEmit` and `bunx eslint ...` on the touched files.
- Result: focused tests, typecheck, and lint passed.
## Risks
- Rename is intentionally blocked until services are stopped, so users may need an extra stop step before renaming.
- Host-service config rewrite assumes Port-managed service records and files; manually edited or orphaned configs may need cleanup.