### PR TITLE
Enter worktree with spaces

### DIFF
--- a/docs/superpowers/specs/2026-06-02-enter-branch-spaces-design.md
+++ b/docs/superpowers/specs/2026-06-02-enter-branch-spaces-design.md
@@ -29,7 +29,7 @@ Today this does not work end to end, for three reasons:
 
 3. **The E2E test harness cannot pass a space.** `execPortAsync` in
    `tests/utils.ts` builds a single shell string with
-   ``` `bun ${cliScript()} ` + args.join(' ') ``` and runs it through a shell.
+   `` `bun ${cliScript()} ` + args.join(' ') `` and runs it through a shell.
    A branch arg `"my feature"` is split into two shell words, and the script
    path itself is unquoted. No faithful E2E for spaced branches can be written
    until this is fixed.

--- a/docs/superpowers/specs/2026-06-02-enter-branch-spaces-design.md
+++ b/docs/superpowers/specs/2026-06-02-enter-branch-spaces-design.md
@@ -13,7 +13,7 @@ any of these forms:
 - `port "my feature"` (implicit, quoted)
 - `port my feature` (implicit, bare words)
 
-Today this does not work end to end, for two reasons:
+Today this does not work end to end, for three reasons:
 
 1. **The argument parser only captures one word.** Both
    `program.command('enter <branch>')` and the implicit catch-all
@@ -21,24 +21,30 @@ Today this does not work end to end, for two reasons:
    `port my feature`, Commander binds `branch = "my"` and treats `feature` as
    excess. The branch name is silently truncated.
 
-2. **The E2E test harness cannot pass a space.** `execPortAsync` in
+2. **Git refs cannot contain spaces.** Even once the full name reaches the
+   worktree layer, `git worktree add -b "my feature"` fails with
+   `fatal: 'my feature' is not a valid branch name`. Git's ref-format rules
+   forbid spaces (and `~`, `:`, `\`, control characters, etc.), so a spaced
+   input cannot be used as the literal branch ref.
+
+3. **The E2E test harness cannot pass a space.** `execPortAsync` in
    `tests/utils.ts` builds a single shell string with
    ``` `bun ${cliScript()} ` + args.join(' ') ``` and runs it through a shell.
    A branch arg `"my feature"` is split into two shell words, and the script
    path itself is unquoted. No faithful E2E for spaced branches can be written
    until this is fixed.
 
-Notably, the **production internals are already space-safe**:
+Notably, parts of the **production internals are already space-safe**:
 
 - `sanitizeBranchName("my feature")` -> `"my-feature"` for the on-disk worktree
   directory, so the path never contains a space.
 - `createWorktree` passes branch/path to `simple-git` as an argv array, so the
-  raw branch name (`"my feature"`) reaches `git worktree add` safely.
+  branch name reaches `git worktree add` without shell splitting.
 - The shell-hook eval output quotes paths/values via `posixShellQuote` /
   `fishShellQuote`, both already unit-tested for spaces.
 
-So the fix is concentrated in **argument parsing** and the **test harness**, not
-in the worktree or shell-eval internals.
+So the fix is concentrated in **argument parsing**, **git ref resolution**, and
+the **test harness**, not in the shell-eval internals.
 
 ## Approach
 
@@ -62,7 +68,30 @@ The early-startup `process.argv[2]` checks (`shouldAutoRegisterWorktree`,
 token only and remain correct: a multi-word branch's first word is not a reserved
 command (and `port enter ...` routes to the `enter` subcommand regardless).
 
-### 2. Space-safe test harness (`tests/utils.ts`)
+### 2. Resolve a valid git ref (`src/lib/git.ts`, `src/commands/enter.ts`)
+
+Git forbids spaces in branch names, so the raw input cannot always be used as the
+ref. Add two helpers to `git.ts`:
+
+- `isValidBranchRef(repoRoot, branch)` — delegates to
+  `git check-ref-format --branch`, the authoritative source of truth (returns
+  false when git would reject the name).
+- `resolveBranchRef(repoRoot, branch)` — returns the raw name when it is already a
+  valid ref (e.g. `feature/auth` keeps its slash), otherwise falls back to
+  `sanitizeBranchName(branch)` (`"my feature"` -> `my-feature`). The sanitized
+  form is always a valid ref and matches the on-disk worktree directory name.
+
+`createWorktree` resolves the ref internally before any branch-existence check or
+`git worktree add`. The worktree **directory** is still derived independently via
+`getWorktreePath` (which sanitizes), so directory naming is unchanged.
+
+`enter.ts` resolves the ref once for its own `branchExists` / `remoteBranchExists`
+checks so existence detection matches the ref that `createWorktree` will use.
+
+`PORT_WORKTREE` and the worktree directory continue to use the sanitized name
+(the worktree identity used for routing/domains) — unchanged.
+
+### 3. Space-safe test harness (`tests/utils.ts`)
 
 Make `execPortAsync` robust to spaces in both the CLI script path and the
 arguments. Use an argv-array exec (`execFile`, no shell) so neither the script
@@ -70,18 +99,16 @@ path nor the args are subject to shell word-splitting. Preserve the existing
 `{ stdout, stderr }` return shape that callers rely on. `renderCLI` already takes
 an args array and is unaffected.
 
-### 3. `enter` command (`src/commands/enter.ts`)
+### 4. `enter` command notes (`src/commands/enter.ts`)
 
-No functional change expected. `enter(branch)` already sanitizes for the
-directory and forwards the raw branch to git. One known, acceptable limitation:
-`getForwardedArgs` (typo-confirmation forwarding) is single-word oriented; it is
-only reached for command-like single-word names, so multi-word branches never
-hit it. Documented, not changed.
+One known, acceptable limitation: `getForwardedArgs` (typo-confirmation
+forwarding) is single-word oriented; it is only reached for command-like
+single-word names, so multi-word branches never hit it. Documented, not changed.
 
 ## Testing
 
-The genuinely new behavior is the parser join. Tests target that plus one
-end-to-end smoke proof.
+The new behavior spans the parser join and git ref resolution. Tests target both
+plus one end-to-end smoke proof.
 
 1. **Unit - `joinBranchArgs`** (colocated test for `src/index.ts`):
    - `["my","feature"]` -> `"my feature"`
@@ -89,16 +116,21 @@ end-to-end smoke proof.
    - `["single"]` -> `"single"`
    - `[]` / `undefined` -> `undefined`
 
-2. **Command-level unit - `src/commands/enter.command.test.ts`** (one case):
-   `enter("my feature")` calls `createWorktree('/repo', 'my feature')` and, under
-   the shell-hook eval path, writes `cd -- '/repo/.port/trees/my-feature'` and
-   `export PORT_WORKTREE='my feature'`. Proves the branch/dir split end to end
-   through the command using existing mocks.
+2. **Unit - `resolveBranchRef`** (in `src/lib/git.test.ts`, real temp git repo):
+   - `"my feature"` -> `"my-feature"` (invalid ref falls back to sanitized)
+   - `"feature/auth"` -> `"feature/auth"` (valid ref preserved, slash kept)
+   - `"simple"` -> `"simple"`
 
-3. **Smoke E2E - `tests/enter-spaces.test.ts`** (modeled on
+3. **Command-level unit - `src/commands/enter.command.test.ts`** (one case):
+   `enter("my feature")` resolves the ref to `my-feature`, calls
+   `createWorktree('/repo', 'my feature')`, and under the shell-hook eval path
+   writes `cd -- '/repo/.port/trees/my-feature'`. `PORT_WORKTREE` uses the
+   sanitized identity `my-feature`. Uses existing mocks.
+
+4. **Smoke E2E - `tests/enter-spaces.test.ts`** (modeled on
    `switch-worktree.test.ts`; lightweight `simple-server` sample, no `up`/Docker):
    - `execPortAsync(['enter', 'my feature'], dir)` -> `.port/trees/my-feature`
-     exists AND `git branch --list "my feature"` shows the branch.
+     exists AND `git branch --list "my-feature"` shows the resolved branch.
    - `execPortAsync(['my feature'], dir)` (implicit form) creates/reuses the same
      worktree.
 
@@ -111,7 +143,7 @@ end-to-end smoke proof.
 
 ## Verification commands
 
-- `bunx vitest run src/index.test.ts src/commands/enter.command.test.ts`
+- `bunx vitest run src/index.test.ts src/lib/git.test.ts src/commands/enter.command.test.ts`
 - `bun run typecheck`
 - `bun run lint`
 - `bunx vitest run tests/enter-spaces.test.ts` (smoke E2E; requires git)

--- a/docs/superpowers/specs/2026-06-02-enter-branch-spaces-design.md
+++ b/docs/superpowers/specs/2026-06-02-enter-branch-spaces-design.md
@@ -1,0 +1,117 @@
+# Support entering worktrees with spaces in the branch name
+
+Issue: https://github.com/jdtzmn/port/issues/114
+Scope: `port enter` and the implicit `port <branch>` entry points.
+
+## Problem
+
+A user should be able to enter a worktree whose branch name contains spaces, in
+any of these forms:
+
+- `port enter "my feature"` (quoted, one arg)
+- `port enter my feature` (bare words, multiple args)
+- `port "my feature"` (implicit, quoted)
+- `port my feature` (implicit, bare words)
+
+Today this does not work end to end, for two reasons:
+
+1. **The argument parser only captures one word.** Both
+   `program.command('enter <branch>')` and the implicit catch-all
+   `program.argument('[branch]')` declare a single positional. Given
+   `port my feature`, Commander binds `branch = "my"` and treats `feature` as
+   excess. The branch name is silently truncated.
+
+2. **The E2E test harness cannot pass a space.** `execPortAsync` in
+   `tests/utils.ts` builds a single shell string with
+   ``` `bun ${cliScript()} ` + args.join(' ') ``` and runs it through a shell.
+   A branch arg `"my feature"` is split into two shell words, and the script
+   path itself is unquoted. No faithful E2E for spaced branches can be written
+   until this is fixed.
+
+Notably, the **production internals are already space-safe**:
+
+- `sanitizeBranchName("my feature")` -> `"my-feature"` for the on-disk worktree
+  directory, so the path never contains a space.
+- `createWorktree` passes branch/path to `simple-git` as an argv array, so the
+  raw branch name (`"my feature"`) reaches `git worktree add` safely.
+- The shell-hook eval output quotes paths/values via `posixShellQuote` /
+  `fishShellQuote`, both already unit-tested for spaces.
+
+So the fix is concentrated in **argument parsing** and the **test harness**, not
+in the worktree or shell-eval internals.
+
+## Approach
+
+### 1. Variadic positional, joined with single spaces (`src/index.ts`)
+
+- Change `enter <branch>` -> `enter <branch...>`. The action receives `string[]`;
+  join with a single space and call `enter(joined)`.
+- Change the implicit catch-all `.argument('[branch]')` -> `.argument('[branch...]')`.
+  The action receives `string[] | undefined`; when non-empty, join with a single
+  space, run the existing `isReservedCommand` check on the joined value, then call
+  `enter(joined)`. When empty/undefined, keep current behavior (TUI when TTY,
+  help otherwise).
+- Extract a tiny pure helper
+  `joinBranchArgs(parts: string[] | undefined): string | undefined` that returns
+  `parts.join(' ')` (or `undefined` when empty). Joining collapses
+  separately-typed words (`my   feature` as distinct argv tokens) into single
+  spaces, matching natural shell behavior and the chosen UX.
+
+The early-startup `process.argv[2]` checks (`shouldAutoRegisterWorktree`,
+`maybeWarnCommandBranchCollision`, `isReservedCommand`) operate on the first
+token only and remain correct: a multi-word branch's first word is not a reserved
+command (and `port enter ...` routes to the `enter` subcommand regardless).
+
+### 2. Space-safe test harness (`tests/utils.ts`)
+
+Make `execPortAsync` robust to spaces in both the CLI script path and the
+arguments. Use an argv-array exec (`execFile`, no shell) so neither the script
+path nor the args are subject to shell word-splitting. Preserve the existing
+`{ stdout, stderr }` return shape that callers rely on. `renderCLI` already takes
+an args array and is unaffected.
+
+### 3. `enter` command (`src/commands/enter.ts`)
+
+No functional change expected. `enter(branch)` already sanitizes for the
+directory and forwards the raw branch to git. One known, acceptable limitation:
+`getForwardedArgs` (typo-confirmation forwarding) is single-word oriented; it is
+only reached for command-like single-word names, so multi-word branches never
+hit it. Documented, not changed.
+
+## Testing
+
+The genuinely new behavior is the parser join. Tests target that plus one
+end-to-end smoke proof.
+
+1. **Unit - `joinBranchArgs`** (colocated test for `src/index.ts`):
+   - `["my","feature"]` -> `"my feature"`
+   - `["my feature"]` -> `"my feature"` (already-quoted single arg)
+   - `["single"]` -> `"single"`
+   - `[]` / `undefined` -> `undefined`
+
+2. **Command-level unit - `src/commands/enter.command.test.ts`** (one case):
+   `enter("my feature")` calls `createWorktree('/repo', 'my feature')` and, under
+   the shell-hook eval path, writes `cd -- '/repo/.port/trees/my-feature'` and
+   `export PORT_WORKTREE='my feature'`. Proves the branch/dir split end to end
+   through the command using existing mocks.
+
+3. **Smoke E2E - `tests/enter-spaces.test.ts`** (modeled on
+   `switch-worktree.test.ts`; lightweight `simple-server` sample, no `up`/Docker):
+   - `execPortAsync(['enter', 'my feature'], dir)` -> `.port/trees/my-feature`
+     exists AND `git branch --list "my feature"` shows the branch.
+   - `execPortAsync(['my feature'], dir)` (implicit form) creates/reuses the same
+     worktree.
+
+### Explicitly out of scope / not tested
+
+- Spaces in the repo/worktree **filesystem path** (separate concern).
+- `port up` + URL polling for a spaced branch (sanitized dir/domain already
+  covered by existing up/down E2Es; spaces never reach the domain).
+- Extra shell permutations (fish/zsh) - covered by existing `shell.test.ts`.
+
+## Verification commands
+
+- `bunx vitest run src/index.test.ts src/commands/enter.command.test.ts`
+- `bun run typecheck`
+- `bun run lint`
+- `bunx vitest run tests/enter-spaces.test.ts` (smoke E2E; requires git)

--- a/src/commands/enter.command.test.ts
+++ b/src/commands/enter.command.test.ts
@@ -13,6 +13,7 @@ const mocks = vi.hoisted(() => ({
   remoteBranchExists: vi.fn(),
   removeWorktree: vi.fn(),
   parseDuplicateWorktreeError: vi.fn(),
+  resolveBranchRef: vi.fn(),
   writeOverrideFile: vi.fn(),
   parseComposeFile: vi.fn(),
   getProjectName: vi.fn(),
@@ -54,6 +55,7 @@ vi.mock('../lib/git.ts', () => ({
   remoteBranchExists: mocks.remoteBranchExists,
   removeWorktree: mocks.removeWorktree,
   parseDuplicateWorktreeError: mocks.parseDuplicateWorktreeError,
+  resolveBranchRef: mocks.resolveBranchRef,
 }))
 
 vi.mock('../lib/compose.ts', () => ({
@@ -130,6 +132,7 @@ describe('enter typo confirmation', () => {
     mocks.worktreeExists.mockReturnValue(false)
     mocks.branchExists.mockResolvedValue(false)
     mocks.remoteBranchExists.mockResolvedValue(false)
+    mocks.resolveBranchRef.mockImplementation(async (_repoRoot: string, branch: string) => branch)
     mocks.findSimilarCommand.mockReturnValue({ command: 'install', distance: 1, similarity: 0.86 })
     mocks.createWorktree.mockResolvedValue('/repo/.port/trees/instal')
     mocks.parseDuplicateWorktreeError.mockReturnValue(null)
@@ -329,6 +332,7 @@ describe('enter with shell hook eval file', () => {
     mocks.hookExists.mockResolvedValue(false)
     mocks.parseComposeFile.mockRejectedValue(new Error('compose missing'))
     mocks.getProjectName.mockReturnValue('repo-feature-1')
+    mocks.resolveBranchRef.mockImplementation(async (_repoRoot: string, branch: string) => branch)
     mocks.branch.mockImplementation((value: string) => value)
     mocks.command.mockImplementation((value: string) => value)
 

--- a/src/commands/enter.command.test.ts
+++ b/src/commands/enter.command.test.ts
@@ -243,6 +243,24 @@ describe('enter typo confirmation', () => {
     expect(mocks.createWorktree).toHaveBeenCalledWith('/repo', 'status')
   })
 
+  test('resolves spaced branch names to a valid ref for existence checks', async () => {
+    // "my feature" is not a valid git ref; it resolves to "my-feature".
+    mocks.findSimilarCommand.mockReturnValue(null)
+    mocks.resolveBranchRef.mockResolvedValue('my-feature')
+    mocks.createWorktree.mockResolvedValue('/repo/.port/trees/my-feature')
+
+    await enter('my feature')
+
+    // The raw name is resolved to a valid ref...
+    expect(mocks.resolveBranchRef).toHaveBeenCalledWith('/repo', 'my feature')
+    // ...and existence checks use the resolved ref, not the raw spaced name.
+    expect(mocks.branchExists).toHaveBeenCalledWith('/repo', 'my-feature')
+    // createWorktree receives the raw branch (it sanitizes the dir + resolves
+    // the ref internally).
+    expect(mocks.createWorktree).toHaveBeenCalledWith('/repo', 'my feature')
+    expect(mocks.prompt).not.toHaveBeenCalled()
+  })
+
   test('reuses an existing worktree when git reports that the branch is already checked out', async () => {
     mocks.createWorktree.mockRejectedValueOnce(
       new Error(

--- a/src/commands/enter.ts
+++ b/src/commands/enter.ts
@@ -12,6 +12,7 @@ import {
   parseDuplicateWorktreeError,
   remoteBranchExists,
   removeWorktree,
+  resolveBranchRef,
 } from '../lib/git.ts'
 import { writeOverrideFile, parseComposeFile, getProjectName } from '../lib/compose.ts'
 import { sanitizeBranchName } from '../lib/sanitize.ts'
@@ -73,8 +74,11 @@ export async function enter(branch: string): Promise<void> {
     worktreePath = getWorktreePath(repoRoot, branch)
     output.dim(`Using existing worktree: ${sanitized}`)
   } else {
-    const localBranch = await branchExists(repoRoot, branch)
-    const remoteBranch = localBranch ? false : await remoteBranchExists(repoRoot, branch)
+    // Git refs cannot contain spaces, so existence checks must use the resolved
+    // ref (e.g. "my feature" → "my-feature") rather than the raw input.
+    const ref = await resolveBranchRef(repoRoot, branch)
+    const localBranch = await branchExists(repoRoot, ref)
+    const remoteBranch = localBranch ? false : await remoteBranchExists(repoRoot, ref)
 
     if (!localBranch && !remoteBranch) {
       const similarCommand = findSimilarCommand(branch)

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -1,0 +1,28 @@
+import { describe, test, expect } from 'vitest'
+import { joinBranchArgs } from './index.ts'
+
+describe('joinBranchArgs', () => {
+  test('joins bare multi-word tokens with a single space', () => {
+    expect(joinBranchArgs(['my', 'feature'])).toBe('my feature')
+  })
+
+  test('collapses extra tokens into single-spaced words', () => {
+    expect(joinBranchArgs(['my', 'cool', 'feature'])).toBe('my cool feature')
+  })
+
+  test('preserves an already-quoted single argument containing spaces', () => {
+    expect(joinBranchArgs(['my feature'])).toBe('my feature')
+  })
+
+  test('returns a single token unchanged', () => {
+    expect(joinBranchArgs(['single'])).toBe('single')
+  })
+
+  test('returns undefined for an empty array', () => {
+    expect(joinBranchArgs([])).toBeUndefined()
+  })
+
+  test('returns undefined for undefined input', () => {
+    expect(joinBranchArgs(undefined)).toBeUndefined()
+  })
+})

--- a/src/index.ts
+++ b/src/index.ts
@@ -40,6 +40,26 @@ import * as output from './lib/output.ts'
 export const program = new Command()
 program.enablePositionalOptions()
 
+/**
+ * Join variadic branch argument tokens into a single branch name.
+ *
+ * Commander collects bare words after `port` / `port enter` as separate argv
+ * entries (e.g. `port my feature` -> ['my', 'feature']). A quoted argument
+ * (`port "my feature"`) arrives as a single entry that already contains the
+ * space. In both cases we join with a single space so the branch name is
+ * reconstructed identically, then defer hostname-safe sanitization to the
+ * worktree layer.
+ *
+ * @param parts - Variadic positional tokens from Commander (may be undefined)
+ * @returns The joined branch name, or undefined when no tokens were provided
+ */
+export function joinBranchArgs(parts: string[] | undefined): string | undefined {
+  if (!parts || parts.length === 0) {
+    return undefined
+  }
+  return parts.join(' ')
+}
+
 function getCliVersion(): string {
   try {
     const packageJsonPath = fileURLToPath(new URL('../package.json', import.meta.url))
@@ -109,11 +129,18 @@ program.command('list').alias('ls').description('Print worktree names, one per l
 // port status
 program.command('status').description('Show service status across all worktrees').action(status)
 
-// port enter <branch>
+// port enter <branch...>
+// Variadic so bare multi-word names (`port enter my feature`) are joined into a
+// single branch name rather than being truncated to the first word.
 program
-  .command('enter <branch>')
+  .command('enter <branch...>')
   .description('Enter a worktree by branch name (works even for command-name branches)')
-  .action(async (branch: string) => {
+  .action(async (branchParts: string[]) => {
+    const branch = joinBranchArgs(branchParts)
+    if (!branch) {
+      program.help()
+      return
+    }
     await enter(branch)
   })
 
@@ -265,8 +292,9 @@ program.hook('preAction', async () => {
 })
 
 program
-  .argument('[branch]', 'Branch name to enter (creates worktree if needed)')
-  .action(async (branch: string | undefined) => {
+  .argument('[branch...]', 'Branch name to enter (creates worktree if needed)')
+  .action(async (branchParts: string[] | undefined) => {
+    const branch = joinBranchArgs(branchParts)
     if (branch) {
       // Check if it looks like a command that wasn't matched
       if (isReservedCommand(branch)) {

--- a/src/lib/exec.test.ts
+++ b/src/lib/exec.test.ts
@@ -58,8 +58,17 @@ async function loadExecModule(overrides?: { execImpl?: ExecImpl; spawnImpl?: Spa
     }
   })
 
+  // execFile is promisified into execFileAsync by exec.ts. These tests don't
+  // exercise it, but the mock must expose it so the import resolves.
+  const execFileMock = vi.fn(
+    (file: string, args: string[], options: unknown, callback: ExecCallback) => {
+      callback(null, 'ok', '')
+    }
+  )
+
   vi.doMock('child_process', () => ({
     exec: execMock,
+    execFile: execFileMock,
     spawn: spawnMock,
   }))
 
@@ -69,6 +78,7 @@ async function loadExecModule(overrides?: { execImpl?: ExecImpl; spawnImpl?: Spa
     execPrivileged: module.execPrivileged,
     execWithStdio: module.execWithStdio,
     execMock,
+    execFileMock,
     spawnMock,
   }
 }

--- a/src/lib/exec.ts
+++ b/src/lib/exec.ts
@@ -1,10 +1,20 @@
-import { exec, spawn, type SpawnOptions } from 'child_process'
+import { exec, execFile, spawn, type SpawnOptions } from 'child_process'
 import { promisify } from 'util'
 
 /**
  * Promisified version of child_process.exec
  */
 export const execAsync = promisify(exec)
+
+/**
+ * Promisified version of child_process.execFile.
+ *
+ * Unlike execAsync, this does NOT spawn a shell: the program and each argument
+ * are passed as a separate argv entry, so paths and arguments containing spaces
+ * (or other shell metacharacters) are preserved verbatim. Prefer this over
+ * execAsync when the program path or any argument may contain spaces.
+ */
+export const execFileAsync = promisify(execFile)
 
 const MACOS_GUI_UNAVAILABLE_ERRORS = [
   'No user interaction allowed',

--- a/src/lib/git.test.ts
+++ b/src/lib/git.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, test, vi } from 'vitest'
+import { beforeEach, describe, expect, test, vi } from 'vitest'
 
 const rawMock = vi.hoisted(() => vi.fn())
 
@@ -12,7 +12,16 @@ vi.mock('./worktree.ts', () => ({
   getWorktreePath: vi.fn((repoRoot: string, branch: string) => `${repoRoot}/.port/trees/${branch}`),
 }))
 
-import { parseDuplicateWorktreeError, renameWorktree } from './git.ts'
+import {
+  isValidBranchRef,
+  parseDuplicateWorktreeError,
+  renameWorktree,
+  resolveBranchRef,
+} from './git.ts'
+
+beforeEach(() => {
+  rawMock.mockReset()
+})
 
 describe('parseDuplicateWorktreeError', () => {
   test('extracts branch and path from duplicate-worktree output', () => {
@@ -42,5 +51,40 @@ describe('renameWorktree', () => {
       '/repo/.port/trees/feature-old',
       '/repo/.port/trees/feature-new',
     ])
+  })
+})
+
+describe('isValidBranchRef', () => {
+  test('returns true when git check-ref-format accepts the name', async () => {
+    rawMock.mockResolvedValueOnce('feature/auth\n')
+
+    await expect(isValidBranchRef('/repo', 'feature/auth')).resolves.toBe(true)
+    expect(rawMock).toHaveBeenCalledWith(['check-ref-format', '--branch', 'feature/auth'])
+  })
+
+  test('returns false when git check-ref-format rejects the name', async () => {
+    rawMock.mockRejectedValueOnce(new Error("fatal: 'my feature' is not a valid branch name"))
+
+    await expect(isValidBranchRef('/repo', 'my feature')).resolves.toBe(false)
+  })
+})
+
+describe('resolveBranchRef', () => {
+  test('preserves a valid ref unchanged (slashes kept)', async () => {
+    rawMock.mockResolvedValueOnce('feature/auth\n')
+
+    await expect(resolveBranchRef('/repo', 'feature/auth')).resolves.toBe('feature/auth')
+  })
+
+  test('falls back to the sanitized name when the raw name is not a valid ref', async () => {
+    rawMock.mockRejectedValueOnce(new Error("fatal: 'my feature' is not a valid branch name"))
+
+    await expect(resolveBranchRef('/repo', 'my feature')).resolves.toBe('my-feature')
+  })
+
+  test('returns a simple valid name unchanged', async () => {
+    rawMock.mockResolvedValueOnce('simple\n')
+
+    await expect(resolveBranchRef('/repo', 'simple')).resolves.toBe('simple')
   })
 })

--- a/src/lib/git.ts
+++ b/src/lib/git.ts
@@ -52,6 +52,48 @@ export function getGit(repoPath: string): SimpleGit {
 }
 
 /**
+ * Check whether a name is a valid git branch ref.
+ *
+ * Delegates to `git check-ref-format --branch`, which is the authoritative
+ * source of truth for ref naming rules (rejects spaces, control characters,
+ * `~`, `:`, `\`, etc.). Returns false when git rejects the name.
+ *
+ * @param repoRoot - The repository root path
+ * @param branch - The candidate branch name
+ * @returns true if git accepts the name as a branch ref
+ */
+export async function isValidBranchRef(repoRoot: string, branch: string): Promise<boolean> {
+  const git = getGit(repoRoot)
+
+  try {
+    await git.raw(['check-ref-format', '--branch', branch])
+    return true
+  } catch {
+    return false
+  }
+}
+
+/**
+ * Resolve the branch name to use as the actual git ref.
+ *
+ * Git forbids spaces (and other characters) in branch names, so a raw input
+ * like `"my feature"` cannot be used as a ref. When the raw name is already a
+ * valid ref (e.g. `feature/auth`) it is preserved as-is; otherwise it falls
+ * back to the hostname-safe sanitized form (`"my feature"` → `my-feature`),
+ * which is always a valid ref and matches the on-disk worktree directory name.
+ *
+ * @param repoRoot - The repository root path
+ * @param branch - The raw branch name supplied by the user
+ * @returns A valid git branch ref name
+ */
+export async function resolveBranchRef(repoRoot: string, branch: string): Promise<string> {
+  if (await isValidBranchRef(repoRoot, branch)) {
+    return branch
+  }
+  return sanitizeBranchName(branch)
+}
+
+/**
  * Check if a branch exists in the repository
  *
  * @param repoRoot - The repository root path
@@ -168,30 +210,27 @@ export async function createWorktree(repoRoot: string, branch: string): Promise<
     throw new GitError(`Worktree already exists at ${worktreePath}`)
   }
 
+  // Git refs cannot contain spaces (and other characters), so derive a valid
+  // ref name. The on-disk worktree path is independently sanitized via
+  // getWorktreePath, so the directory name is unaffected by this resolution.
+  const ref = await resolveBranchRef(repoRoot, branch)
+
   try {
-    const localExists = await branchExists(repoRoot, branch)
+    const localExists = await branchExists(repoRoot, ref)
 
     if (localExists) {
       // Branch exists locally, create worktree for it
-      await git.raw(['worktree', 'add', worktreePath, branch])
+      await git.raw(['worktree', 'add', worktreePath, ref])
     } else {
       // Check if branch exists on remote
-      const remoteExists = await remoteBranchExists(repoRoot, branch)
+      const remoteExists = await remoteBranchExists(repoRoot, ref)
 
       if (remoteExists) {
         // Track the remote branch
-        await git.raw([
-          'worktree',
-          'add',
-          '--track',
-          '-b',
-          branch,
-          worktreePath,
-          `origin/${branch}`,
-        ])
+        await git.raw(['worktree', 'add', '--track', '-b', ref, worktreePath, `origin/${ref}`])
       } else {
         // Create new branch from HEAD
-        await git.raw(['worktree', 'add', '-b', branch, worktreePath])
+        await git.raw(['worktree', 'add', '-b', ref, worktreePath])
       }
     }
 

--- a/tests/basics.test.ts
+++ b/tests/basics.test.ts
@@ -47,7 +47,7 @@ test('Help includes the cleanup command', async () => {
 test('Help includes the enter command', async () => {
   const { findByText } = await renderCLI(['--help'])
 
-  const instance = await findByText(/enter <branch>/)
+  const instance = await findByText(/enter <branch\.\.\.>/)
   expect(instance).toBeInTheConsole()
 })
 

--- a/tests/enter-spaces.test.ts
+++ b/tests/enter-spaces.test.ts
@@ -1,0 +1,51 @@
+import { join } from 'path'
+import { existsSync } from 'fs'
+import { test, expect } from 'vitest'
+import { execPortAsync, prepareSample } from './utils'
+import { execFileAsync } from '../src/lib/exec'
+
+const TIMEOUT = 60000
+
+/**
+ * Return true if a local branch with the exact given name exists.
+ *
+ * Uses execFile (no shell) so the branch name is matched verbatim, which keeps
+ * names containing spaces or other metacharacters intact.
+ */
+async function localBranchExists(repoDir: string, branch: string): Promise<boolean> {
+  const { stdout } = await execFileAsync('git', ['branch', '--list', branch], { cwd: repoDir })
+  return stdout.trim().length > 0
+}
+
+test(
+  'enters a worktree for a branch name with spaces (explicit and implicit forms)',
+  async () => {
+    const sample = await prepareSample('simple-server', {
+      initWithConfig: true,
+    })
+
+    try {
+      // Explicit form: `port enter my feature` (bare multi-word args).
+      // The branch name is not a valid git ref, so it resolves to "my-feature"
+      // for both the git branch and the on-disk worktree directory.
+      await execPortAsync(['enter', 'my feature'], sample.dir)
+
+      const worktreePath = join(sample.dir, '.port/trees/my-feature')
+      expect(existsSync(worktreePath)).toBe(true)
+      expect(await localBranchExists(sample.dir, 'my-feature')).toBe(true)
+      // The raw spaced name is never used as an actual git ref.
+      expect(await localBranchExists(sample.dir, 'my feature')).toBe(false)
+
+      // Implicit form: `port my feature` reuses the same worktree (idempotent),
+      // and does not create a duplicate or a nested worktree.
+      await execPortAsync(['my', 'feature'], sample.dir)
+
+      expect(existsSync(worktreePath)).toBe(true)
+      const nestedPath = join(worktreePath, '.port/trees/my-feature')
+      expect(existsSync(nestedPath)).toBe(false)
+    } finally {
+      await sample.cleanup()
+    }
+  },
+  TIMEOUT
+)

--- a/tests/utils.ts
+++ b/tests/utils.ts
@@ -3,7 +3,7 @@ import { basename, join, resolve } from 'path'
 import { cp, mkdtemp, readdir, rm, writeFile } from 'fs/promises'
 import { tmpdir } from 'os'
 import type { PortConfig } from '../src/types'
-import { execAsync } from '../src/lib/exec'
+import { execAsync, execFileAsync } from '../src/lib/exec'
 import { CONFIG_FILE, PORT_DIR, TREES_DIR } from '../src/lib/config'
 import { sanitizeFolderName } from '../src/lib/sanitize'
 
@@ -28,7 +28,10 @@ export function renderCLI(args: string[] = [], cwd?: string) {
 }
 
 export async function execPortAsync(args: string[] = [], cwd?: string) {
-  return execAsync(`bun ${cliScript()} ` + args.join(' '), {
+  // Use execFile (no shell) so the CLI script path and individual args are
+  // passed verbatim. This keeps branch names containing spaces intact instead
+  // of letting the shell split them into separate words.
+  return execFileAsync('bun', [cliScript(), ...args], {
     cwd,
   })
 }


### PR DESCRIPTION
## Summary
- Support entering worktrees whose branch name contains spaces via `port enter` and the implicit `port <branch>` form, in all forms: `port enter "my feature"`, `port enter my feature`, `port "my feature"`, and `port my feature`.
- Parse branch arguments as variadic positionals and join bare words into a single name (new exported `joinBranchArgs` helper in `src/index.ts`).
- Resolve a valid git ref before worktree creation: names git rejects (spaces, etc.) fall back to the sanitized form (`my feature` → branch `my-feature`), while valid refs like `feature/auth` are preserved (new `isValidBranchRef` / `resolveBranchRef` in `src/lib/git.ts`, used by `enter.ts`). Worktree directory naming and `PORT_WORKTREE` identity stay sanitized and unchanged.
- Make the test harness space-safe: `execPortAsync` now uses `execFile` (no shell) so spaced args and script paths survive (`tests/utils.ts`, `src/lib/exec.ts`).
- Add a design doc under `docs/superpowers/specs/`.

## Testing
- `joinBranchArgs` unit tests (`src/index.test.ts`); `isValidBranchRef` / `resolveBranchRef` unit tests (`src/lib/git.test.ts`); command-level spaced-branch case (`src/commands/enter.command.test.ts`); smoke E2E covering explicit and implicit forms (`tests/enter-spaces.test.ts`).
- Result: targeted test set passing (68 tests across touched files); `typecheck` clean; `lint` 0 errors (only pre-existing unrelated warnings); `prettier` clean.

## Risks
- Behavioral change: spaced/invalid branch names now resolve to a sanitized git ref instead of erroring; valid refs (e.g. with slashes) are unaffected.
- None noted for rollout; change is scoped to the `enter` / implicit entry points and the test harness, with no change to worktree directory or domain/routing identity.

_(Drafted by Jacob's coding agent on his behalf)_
