### PR TITLE
chore: bump version to 0.3.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jdtzmn/port",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "description": "CLI tool for managing git worktrees with automatic Traefik configuration",
   "author": "Jacob Daitzman <jdtzmn@gmail.com>",
   "repository": {


### PR DESCRIPTION
Bumps the package version from `0.2.0` to `0.3.0`.

A **minor** bump is appropriate because the changes since v0.2.0 include backwards-compatible new features (not just fixes):

- New `port rename` / `port mv` command (#112)
- Selective services for `port up`/`port down` (`port up [services...]`) (#100)

Other changes since v0.2.0 are fixes/internal: #99, #105, #106, #109, #111, #115.

Mirrors the prior bump PR #96 (`chore: bump version to 0.2.0`) — a single-line `package.json` change. Publishing the GitHub Release `v0.3.0` after merge will trigger the npm + Docker publish workflow.

_(Drafted by Jacob's coding agent on his behalf)_