### PR TITLE
Add pre-run hook for port run

### DIFF
--- a/README.md
+++ b/README.md
@@ -320,13 +320,22 @@ Port supports executable shell hooks in `.port/hooks/`:
 
 - `post-create.sh`: runs after a new worktree is created by `port enter <branch>`
 - `post-up.sh`: runs after `port up [services...]` successfully starts services
+- `pre-run.sh`: runs before `port run <port> -- <command...>` starts the host process
 
-Both hooks receive these environment variables:
+Hooks receive these environment variables:
 
 - `PORT_ROOT_PATH`
 - `PORT_WORKTREE_PATH`
 - `PORT_BRANCH`
 - `PORT_DOMAIN`
+
+`pre-run.sh` also receives `PORT_LOGICAL_PORT`, `PORT_ACTUAL_PORT`, and `PORT_ENV_FILE`. Append `KEY=VALUE` lines to `$PORT_ENV_FILE` to override environment variables for the command spawned by `port run`:
+
+```bash
+if [ -n "${DATABASE_URL:-}" ]; then
+  echo "DATABASE_URL=${DATABASE_URL/localhost:5432/$PORT_BRANCH.$PORT_DOMAIN:5432}" >> "$PORT_ENV_FILE"
+fi
+```
 
 Manual hook commands:
 

--- a/src/commands/init.ts
+++ b/src/commands/init.ts
@@ -9,6 +9,7 @@ import {
   HOOKS_DIR,
   POST_CREATE_HOOK,
   POST_UP_HOOK,
+  PRE_RUN_HOOK,
   PORT_RUNTIME_GITIGNORE,
   getPortDir,
   getConfigPath,
@@ -70,6 +71,31 @@ const POST_UP_HOOK_TEMPLATE = `#!/bin/bash
 # Uncomment and customize below:
 # echo "Opening app for $PORT_BRANCH..."
 # open "http://$PORT_BRANCH.$PORT_DOMAIN:3000"
+`
+
+/** Pre-run hook template */
+const PRE_RUN_HOOK_TEMPLATE = `#!/bin/bash
+# Port pre-run hook
+# Runs before 'port run <port> -- <command...>' starts the host process
+#
+# Available environment variables:
+#   PORT_ROOT_PATH     - Absolute path to the main repository root
+#   PORT_WORKTREE_PATH - Absolute path to the current worktree
+#   PORT_BRANCH        - The branch name (sanitized)
+#   PORT_DOMAIN        - Configured domain suffix (for example: port)
+#   PORT_LOGICAL_PORT  - The port users access via <branch>.<domain>:PORT
+#   PORT_ACTUAL_PORT   - The ephemeral local port assigned to the process
+#   PORT_ENV_FILE      - Append KEY=VALUE lines here to override command env
+#
+# Exit non-zero to abort the host process before it starts.
+#
+# Example: point DATABASE_URL at this worktree's routed database host
+#   if [ -n "\${DATABASE_URL:-}" ]; then
+#     echo "DATABASE_URL=\${DATABASE_URL/localhost:5432/$PORT_BRANCH.$PORT_DOMAIN:5432}" >> "$PORT_ENV_FILE"
+#   fi
+
+# Uncomment and customize below:
+# echo "Preparing run env for $PORT_BRANCH..."
 `
 
 /** User compose override template */
@@ -148,6 +174,7 @@ export async function init(): Promise<void> {
   const hooksDir = getHooksDir(repoRoot)
   const postCreateHookPath = getHookPath(repoRoot, 'post-create')
   const postUpHookPath = getHookPath(repoRoot, 'post-up')
+  const preRunHookPath = getHookPath(repoRoot, 'pre-run')
 
   if (!existsSync(hooksDir)) {
     await mkdir(hooksDir, { recursive: true })
@@ -168,6 +195,14 @@ export async function init(): Promise<void> {
     output.success(`Created ${PORT_DIR}/${HOOKS_DIR}/${POST_UP_HOOK}`)
   } else {
     output.dim(`${PORT_DIR}/${HOOKS_DIR}/${POST_UP_HOOK} already exists`)
+  }
+
+  if (!existsSync(preRunHookPath)) {
+    await writeFile(preRunHookPath, PRE_RUN_HOOK_TEMPLATE)
+    await chmod(preRunHookPath, 0o755) // Make executable
+    output.success(`Created ${PORT_DIR}/${HOOKS_DIR}/${PRE_RUN_HOOK}`)
+  } else {
+    output.dim(`${PORT_DIR}/${HOOKS_DIR}/${PRE_RUN_HOOK} already exists`)
   }
 
   // Create user override compose template

--- a/src/commands/run.pre-run.test.ts
+++ b/src/commands/run.pre-run.test.ts
@@ -1,11 +1,28 @@
-import { EventEmitter } from 'events'
-import { mkdir, rm, writeFile, chmod } from 'fs/promises'
+import { mkdir, readFile, rm, writeFile, chmod } from 'fs/promises'
 import { join } from 'path'
 import { tmpdir } from 'os'
 import { mkdtempSync } from 'fs'
 import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest'
 import type { ChildProcess } from 'child_process'
 import { PORT_DIR, HOOKS_DIR } from '../lib/config.ts'
+
+async function readFileEventually(path: string, timeoutMs = 2000): Promise<string> {
+  const start = Date.now()
+
+  while (Date.now() - start < timeoutMs) {
+    try {
+      return await readFile(path, 'utf8')
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code !== 'ENOENT') {
+        throw error
+      }
+
+      await new Promise(resolve => setTimeout(resolve, 25))
+    }
+  }
+
+  return readFile(path, 'utf8')
+}
 
 const mocks = vi.hoisted(() => {
   return {
@@ -16,6 +33,7 @@ const mocks = vi.hoisted(() => {
       args: string[]
       options: { env?: NodeJS.ProcessEnv }
     }>,
+    spawnedChildren: [] as ChildProcess[],
   }
 })
 
@@ -31,8 +49,8 @@ vi.mock('child_process', async importOriginal => {
 
       mocks.spawnedCommands.push({ cmd, args, options })
 
-      const child = new EventEmitter() as ChildProcess & { pid: number }
-      child.pid = 12345
+      const child = actual.spawn(cmd, args, options)
+      mocks.spawnedChildren.push(child)
       return child
     }),
   }
@@ -91,6 +109,7 @@ describe('port run pre-run hook', () => {
     mocks.repoRoot = mkdtempSync(join(tmpdir(), 'port-run-pre-run-test-'))
     mocks.worktreePath = join(mocks.repoRoot, PORT_DIR, 'trees', 'feature-1')
     mocks.spawnedCommands = []
+    mocks.spawnedChildren = []
 
     const hooksDir = join(mocks.repoRoot, PORT_DIR, HOOKS_DIR)
     await mkdir(hooksDir, { recursive: true })
@@ -117,15 +136,36 @@ describe('port run pre-run hook', () => {
     } else {
       process.env.DATABASE_URL = originalDatabaseUrl
     }
+    for (const child of mocks.spawnedChildren) {
+      child.removeAllListeners('exit')
+      child.removeAllListeners('error')
+      if (!child.killed) {
+        child.kill()
+      }
+    }
 
     await rm(mocks.repoRoot, { recursive: true, force: true })
   })
 
-  test('runs pre-run before spawning the host process and applies env overrides', async () => {
-    await run(3000, ['bun', 'run', 'dev'])
+  test('runs pre-run before the host process and applies env overrides to the running script', async () => {
+    const observedEnvPath = join(mocks.worktreePath, 'observed-env.json')
+    const script = [
+      `await Bun.write(${JSON.stringify(observedEnvPath)}, JSON.stringify({`,
+      '  PORT: process.env.PORT,',
+      '  DATABASE_URL: process.env.DATABASE_URL,',
+      '  HOOK_MARKER: process.env.HOOK_MARKER,',
+      '}))',
+      'setInterval(() => {}, 1000)',
+    ].join('\n')
+
+    await run(3000, ['bun', '-e', script])
 
     expect(mocks.spawnedCommands).toHaveLength(1)
-    expect(mocks.spawnedCommands[0]?.options.env).toMatchObject({
+    const observedEnv = JSON.parse(await readFileEventually(observedEnvPath)) as Record<
+      string,
+      string
+    >
+    expect(observedEnv).toMatchObject({
       PORT: '49152',
       DATABASE_URL: 'postgres://user:pass@feature-1.port:5432/app_db',
       HOOK_MARKER: 'ran',

--- a/src/commands/run.pre-run.test.ts
+++ b/src/commands/run.pre-run.test.ts
@@ -1,0 +1,134 @@
+import { EventEmitter } from 'events'
+import { mkdir, rm, writeFile, chmod } from 'fs/promises'
+import { join } from 'path'
+import { tmpdir } from 'os'
+import { mkdtempSync } from 'fs'
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest'
+import type { ChildProcess } from 'child_process'
+import { PORT_DIR, HOOKS_DIR } from '../lib/config.ts'
+
+const mocks = vi.hoisted(() => {
+  return {
+    repoRoot: '',
+    worktreePath: '',
+    spawnedCommands: [] as Array<{
+      cmd: string
+      args: string[]
+      options: { env?: NodeJS.ProcessEnv }
+    }>,
+  }
+})
+
+vi.mock('child_process', async importOriginal => {
+  const actual = await importOriginal<typeof import('child_process')>()
+
+  return {
+    ...actual,
+    spawn: vi.fn((cmd: string, args: string[] = [], options: { env?: NodeJS.ProcessEnv } = {}) => {
+      if (cmd.includes(`/${PORT_DIR}/${HOOKS_DIR}/`)) {
+        return actual.spawn(cmd, args, options)
+      }
+
+      mocks.spawnedCommands.push({ cmd, args, options })
+
+      const child = new EventEmitter() as ChildProcess & { pid: number }
+      child.pid = 12345
+      return child
+    }),
+  }
+})
+
+vi.mock('../lib/worktree.ts', () => ({
+  detectWorktree: () => ({
+    repoRoot: mocks.repoRoot,
+    worktreePath: mocks.worktreePath,
+    name: 'feature-1',
+    isMainRepo: false,
+  }),
+}))
+
+vi.mock('../lib/config.ts', async importOriginal => {
+  const actual = await importOriginal<typeof import('../lib/config.ts')>()
+  return {
+    ...actual,
+    ensurePortRuntimeDir: vi.fn(),
+    loadConfigOrDefault: vi.fn(async () => ({ domain: 'port' })),
+  }
+})
+
+vi.mock('../lib/registry.ts', () => ({
+  getHostService: vi.fn(async () => undefined),
+}))
+
+vi.mock('../lib/traefik.ts', () => ({
+  ensureTraefikPorts: vi.fn(async () => false),
+  traefikFilesExist: vi.fn(() => true),
+  initTraefikFiles: vi.fn(),
+}))
+
+vi.mock('../lib/compose.ts', () => ({
+  isTraefikRunning: vi.fn(async () => true),
+  startTraefik: vi.fn(),
+  restartTraefik: vi.fn(),
+}))
+
+vi.mock('../lib/hostService.ts', () => ({
+  cleanupStaleHostServices: vi.fn(),
+  findAvailablePort: vi.fn(async () => 49152),
+  writeHostServiceConfig: vi.fn(async () => '/tmp/port-host-service.yml'),
+  removeHostServiceConfig: vi.fn(),
+  registerHostService: vi.fn(),
+  unregisterHostService: vi.fn(),
+  stopHostService: vi.fn(),
+}))
+
+const { run } = await import('./run.ts')
+
+describe('port run pre-run hook', () => {
+  const originalDatabaseUrl = process.env.DATABASE_URL
+
+  beforeEach(async () => {
+    mocks.repoRoot = mkdtempSync(join(tmpdir(), 'port-run-pre-run-test-'))
+    mocks.worktreePath = join(mocks.repoRoot, PORT_DIR, 'trees', 'feature-1')
+    mocks.spawnedCommands = []
+
+    const hooksDir = join(mocks.repoRoot, PORT_DIR, HOOKS_DIR)
+    await mkdir(hooksDir, { recursive: true })
+    await mkdir(mocks.worktreePath, { recursive: true })
+
+    const hookPath = join(hooksDir, 'pre-run.sh')
+    await writeFile(
+      hookPath,
+      [
+        '#!/bin/bash',
+        'set -euo pipefail',
+        'echo "DATABASE_URL=${DATABASE_URL/localhost:5432/$PORT_BRANCH.$PORT_DOMAIN:5432}" >> "$PORT_ENV_FILE"',
+        'echo "HOOK_MARKER=ran" >> "$PORT_ENV_FILE"',
+      ].join('\n')
+    )
+    await chmod(hookPath, 0o755)
+
+    process.env.DATABASE_URL = 'postgres://user:pass@localhost:5432/app_db'
+  })
+
+  afterEach(async () => {
+    if (originalDatabaseUrl === undefined) {
+      delete process.env.DATABASE_URL
+    } else {
+      process.env.DATABASE_URL = originalDatabaseUrl
+    }
+
+    await rm(mocks.repoRoot, { recursive: true, force: true })
+  })
+
+  test('runs pre-run before spawning the host process and applies env overrides', async () => {
+    await run(3000, ['bun', 'run', 'dev'])
+
+    expect(mocks.spawnedCommands).toHaveLength(1)
+    expect(mocks.spawnedCommands[0]?.options.env).toMatchObject({
+      PORT: '49152',
+      DATABASE_URL: 'postgres://user:pass@feature-1.port:5432/app_db',
+      HOOK_MARKER: 'ran',
+    })
+  })
+})

--- a/src/commands/run.ts
+++ b/src/commands/run.ts
@@ -1,4 +1,7 @@
 import { spawn, type ChildProcess } from 'child_process'
+import { mkdtemp, readFile, rm, writeFile } from 'fs/promises'
+import { join } from 'path'
+import { tmpdir } from 'os'
 import inquirer from 'inquirer'
 import { detectWorktree } from '../lib/worktree.ts'
 import { loadConfigOrDefault, ensurePortRuntimeDir } from '../lib/config.ts'
@@ -16,6 +19,33 @@ import {
 } from '../lib/hostService.ts'
 import type { HostService } from '../types.ts'
 import * as output from '../lib/output.ts'
+import { hookExists, runPreRunHook } from '../lib/hooks.ts'
+
+function parseEnvOverrides(content: string): NodeJS.ProcessEnv {
+  const overrides: NodeJS.ProcessEnv = {}
+
+  for (const line of content.split(/\r?\n/)) {
+    const trimmed = line.trim()
+
+    if (!trimmed || trimmed.startsWith('#')) {
+      continue
+    }
+
+    const equalsIndex = trimmed.indexOf('=')
+    if (equalsIndex <= 0) {
+      continue
+    }
+
+    const key = trimmed.slice(0, equalsIndex)
+    if (!/^[A-Za-z_][A-Za-z0-9_]*$/.test(key)) {
+      continue
+    }
+
+    overrides[key] = trimmed.slice(equalsIndex + 1)
+  }
+
+  return overrides
+}
 
 /**
  * Run a host process with Traefik routing
@@ -136,6 +166,38 @@ export async function run(logicalPort: number, command: string[]): Promise<void>
     await unregisterHostService(repoRoot, branch, logicalPort)
   }
 
+  let envOverrides: NodeJS.ProcessEnv = {}
+  if (await hookExists(repoRoot, 'pre-run')) {
+    const envDir = await mkdtemp(join(tmpdir(), 'port-pre-run-'))
+    const envFile = join(envDir, 'env')
+
+    try {
+      await writeFile(envFile, '')
+      output.info('Running pre-run hook...')
+      const result = await runPreRunHook({
+        repoRoot,
+        worktreePath: worktreeInfo.worktreePath,
+        branch,
+        domain,
+        logicalPort,
+        actualPort,
+        envFile,
+      })
+
+      if (!result.success) {
+        output.error(`Pre-run hook failed (exit code ${result.exitCode})`)
+        output.dim('See .port/logs/latest.log for details')
+        await cleanup()
+        process.exit(result.exitCode)
+      }
+
+      envOverrides = parseEnvOverrides(await readFile(envFile, 'utf8'))
+      output.success('Pre-run hook completed')
+    } finally {
+      await rm(envDir, { recursive: true, force: true })
+    }
+  }
+
   // Set up signal handlers
   let cleanupDone = false
   const handleSignal = async (signal: string, exitCode: number) => {
@@ -169,6 +231,7 @@ export async function run(logicalPort: number, command: string[]): Promise<void>
     stdio: 'inherit',
     env: {
       ...process.env,
+      ...envOverrides,
       PORT: actualPort.toString(),
     },
   })

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -36,6 +36,9 @@ export const POST_CREATE_HOOK = 'post-create.sh'
 /** Post-up hook file name */
 export const POST_UP_HOOK = 'post-up.sh'
 
+/** Pre-run hook file name */
+export const PRE_RUN_HOOK = 'pre-run.sh'
+
 /** Default domain suffix */
 export const DEFAULT_DOMAIN = 'port'
 

--- a/src/lib/hooks.test.ts
+++ b/src/lib/hooks.test.ts
@@ -15,6 +15,7 @@ import {
   runHook,
   runPostCreateHook,
   runPostUpHook,
+  runPreRunHook,
   type HookEnv,
 } from './hooks.ts'
 import { PORT_DIR, HOOKS_DIR, LOGS_DIR, LATEST_LOG } from './config.ts'
@@ -81,12 +82,13 @@ describe('Path helper functions', () => {
 
 describe('hook definitions', () => {
   test('includes all hook names from definitions', () => {
-    expect(HOOK_NAMES).toEqual(['post-create', 'post-up'])
+    expect(HOOK_NAMES).toEqual(['post-create', 'post-up', 'pre-run'])
   })
 
-  test('allows post-up in main repo but restricts post-create', () => {
+  test('allows post-up in main repo but restricts worktree-only hooks', () => {
     expect(canRunHookInContext('post-up', true)).toBe(true)
     expect(canRunHookInContext('post-create', true)).toBe(false)
+    expect(canRunHookInContext('pre-run', true)).toBe(false)
   })
 })
 
@@ -593,5 +595,57 @@ echo "DOMAIN=$PORT_DOMAIN" >> "${outputFile}"
     const content = readFileSync(outputFile, 'utf-8')
     expect(content).toContain('BRANCH=feature/test')
     expect(content).toContain('DOMAIN=port')
+  })
+})
+
+describe('runPreRunHook', () => {
+  let repoRoot: string
+  let worktreePath: string
+
+  beforeEach(async () => {
+    repoRoot = await setupMockRepo()
+    worktreePath = join(repoRoot, '.port', 'trees', 'test-branch')
+    await mkdir(worktreePath, { recursive: true })
+  })
+
+  afterEach(async () => {
+    await rm(repoRoot, { recursive: true, force: true })
+  })
+
+  test('passes run-specific env values and env file path', async () => {
+    const outputFile = join(repoRoot, 'env-check-run.txt')
+    const envFile = join(repoRoot, 'pre-run.env')
+    await createExecutableScript(
+      getHooksDir(repoRoot),
+      'pre-run.sh',
+      `#!/bin/bash
+echo "BRANCH=$PORT_BRANCH" >> "${outputFile}"
+echo "DOMAIN=$PORT_DOMAIN" >> "${outputFile}"
+echo "LOGICAL=$PORT_LOGICAL_PORT" >> "${outputFile}"
+echo "ACTUAL=$PORT_ACTUAL_PORT" >> "${outputFile}"
+echo "ENV_FILE=$PORT_ENV_FILE" >> "${outputFile}"
+echo "HOOK_MARKER=ran" >> "$PORT_ENV_FILE"
+`
+    )
+
+    const result = await runPreRunHook({
+      repoRoot,
+      worktreePath,
+      branch: 'feature/test',
+      domain: 'port',
+      logicalPort: 3000,
+      actualPort: 49152,
+      envFile,
+    })
+
+    expect(result.success).toBe(true)
+
+    const content = readFileSync(outputFile, 'utf-8')
+    expect(content).toContain('BRANCH=feature/test')
+    expect(content).toContain('DOMAIN=port')
+    expect(content).toContain('LOGICAL=3000')
+    expect(content).toContain('ACTUAL=49152')
+    expect(content).toContain(`ENV_FILE=${envFile}`)
+    expect(readFileSync(envFile, 'utf-8')).toContain('HOOK_MARKER=ran')
   })
 })

--- a/src/lib/hooks.ts
+++ b/src/lib/hooks.ts
@@ -21,6 +21,9 @@ export const HOOK_DEFINITIONS = {
   'post-up': {
     manualScopes: ['worktree', 'main'],
   },
+  'pre-run': {
+    manualScopes: ['worktree'],
+  },
 } as const satisfies Record<string, HookDefinition>
 
 /** Available hook names derived from HOOK_DEFINITIONS */
@@ -50,6 +53,12 @@ export interface HookEnv {
   PORT_BRANCH?: string
   /** Domain suffix from port config */
   PORT_DOMAIN?: string
+  /** File path where hooks can append KEY=VALUE lines to override child env */
+  PORT_ENV_FILE?: string
+  /** Logical port requested by the user */
+  PORT_LOGICAL_PORT?: string
+  /** Actual ephemeral port allocated for the host process */
+  PORT_ACTUAL_PORT?: string
 }
 
 /**
@@ -276,6 +285,39 @@ export async function runPostUpHook(options: {
       PORT_WORKTREE_PATH: worktreePath,
       PORT_BRANCH: branch,
       PORT_DOMAIN: domain,
+    },
+    branch
+  )
+}
+
+/**
+ * Run the pre-run hook before starting a host process.
+ *
+ * The hook can append KEY=VALUE lines to PORT_ENV_FILE to override environment
+ * variables passed to the spawned command.
+ */
+export async function runPreRunHook(options: {
+  repoRoot: string
+  worktreePath: string
+  branch: string
+  domain: string
+  logicalPort: number
+  actualPort: number
+  envFile: string
+}): Promise<HookResult> {
+  const { repoRoot, worktreePath, branch, domain, logicalPort, actualPort, envFile } = options
+
+  return runHook(
+    repoRoot,
+    'pre-run',
+    {
+      PORT_ROOT_PATH: repoRoot,
+      PORT_WORKTREE_PATH: worktreePath,
+      PORT_BRANCH: branch,
+      PORT_DOMAIN: domain,
+      PORT_LOGICAL_PORT: logicalPort.toString(),
+      PORT_ACTUAL_PORT: actualPort.toString(),
+      PORT_ENV_FILE: envFile,
     },
     branch
   )


### PR DESCRIPTION
## Summary

- Add a `pre-run.sh` lifecycle hook that runs before `port run` starts its host process.
- Provide `PORT_ENV_FILE` so the hook can append `KEY=VALUE` lines that override the spawned command environment.
- Add `PORT_LOGICAL_PORT` and `PORT_ACTUAL_PORT` to the pre-run hook environment.
- Add coverage for rewriting `DATABASE_URL` from `localhost:5432` to `<branch>.<domain>:5432` before the child process starts.
- Document the hook and add the template during `port init`.

## Validation

- `bunx vitest run src/commands/run.pre-run.test.ts src/lib/hooks.test.ts src/commands/hook.test.ts`
- `bun run typecheck`
- `bun run build`
- `bun run lint` (passes with existing warnings in `src/commands/remove.test.ts`)

Known unrelated issue tracked as `port-pap`: `bunx vitest run src/commands/prune.test.ts` fails in `exits current worktree before pruning it`, and the full suite timed out after surfacing that failure.

_(Drafted by Jacob's coding agent on his behalf)_
