### PR TITLE
ci: bump Node to 22 in publish workflow for npm@latest compatibility

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -37,7 +37,7 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 22
           registry-url: https://registry.npmjs.org
 
       - name: Update npm


### PR DESCRIPTION
The publish workflow was pinned to Node 20, but `npm@latest` (v12.0.1) now requires Node `^22.22.2 || ^24.15.0 || >=26.0.0`. Bumps `node-version: 20` → `22` so the publish step succeeds.

Fixes the failing publish run: https://github.com/jdtzmn/port/actions/runs/29637971872/job/88064340263#step:5:15

_(Drafted by Jacob's coding agent on his behalf)_