### PR TITLE
chore: bump version to 0.4.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jdtzmn/port",
-  "version": "0.3.1",
+  "version": "0.4.0",
   "description": "CLI tool for managing git worktrees with automatic Traefik configuration",
   "author": "Jacob Daitzman <jdtzmn@gmail.com>",
   "repository": {


### PR DESCRIPTION
Bumps the package version from `0.3.1` to `0.4.0`.

A **minor** bump is appropriate because the changes since v0.3.1 include a backwards-compatible new feature (not just fixes):

- Expose `PORT_HOSTNAME`/`PORT_HOSTNAME_LABEL` (already-truncated hostname) to hooks and `override-compose.yml` (#131)

Other changes since v0.3.1 are internal/CI: #126.

Mirrors the prior bump PR #116 (`chore: bump version to 0.3.0`) — a single-line `package.json` change. Publishing the GitHub Release `v0.4.0` after merge will trigger the npm + Docker publish workflow.

_(Drafted by Jacob's coding agent on his behalf)_
