### PR TITLE
Show port run services in 404 fallback page

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -216,3 +216,6 @@ $RECYCLE.BIN/
 *.lnk
 
 # End of https://www.toptal.com/developers/gitignore/api/macos,windows,linux,node
+
+# Devin local session configuration
+.devin/

--- a/packages/404-app/app/api/host-services/route.ts
+++ b/packages/404-app/app/api/host-services/route.ts
@@ -1,0 +1,86 @@
+import { NextResponse } from 'next/server'
+import { readFile } from 'fs/promises'
+import { existsSync } from 'fs'
+
+export const dynamic = 'force-dynamic'
+
+interface HostService {
+  repo: string
+  branch: string
+  logicalPort: number
+  actualPort: number
+  pid: number
+  configFile: string
+}
+
+interface Registry {
+  projects: any[]
+  hostServices?: HostService[]
+}
+
+interface ServiceEntry {
+  name: string
+  port: number
+  url: string
+}
+
+interface WorktreeEntry {
+  name: string
+  services: ServiceEntry[]
+}
+
+/**
+ * Get host services from the port registry
+ * Returns worktree entries with their services grouped by worktree name
+ * Note: This doesn't filter by process status since PIDs are not accessible
+ * from within the Docker container. Stale services are cleaned up by
+ * cleanupStaleHostServices() when port commands are run.
+ */
+export async function GET() {
+  try {
+    const registryPath = process.env.PORT_REGISTRY_PATH || '/mnt/port-data/registry.json'
+
+    if (!existsSync(registryPath)) {
+      return NextResponse.json([])
+    }
+
+    const content = await readFile(registryPath, 'utf8')
+    const registry = JSON.parse(content) as Registry
+
+    if (!registry.hostServices || registry.hostServices.length === 0) {
+      return NextResponse.json([])
+    }
+
+    const worktreeMap = new Map<string, ServiceEntry[]>()
+    const domain = 'port' // Default domain - could be enhanced to read from config
+
+    for (const service of registry.hostServices) {
+      const worktreeName = service.branch
+      const serviceName = 'host-service' // Generic name for host services
+      const port = service.logicalPort
+      const url = `http://${service.branch}.${domain}:${port}`
+
+      if (!worktreeMap.has(worktreeName)) {
+        worktreeMap.set(worktreeName, [])
+      }
+
+      const existing = worktreeMap.get(worktreeName)!
+      const alreadyAdded = existing.some(s => s.name === serviceName && s.port === port)
+      if (!alreadyAdded) {
+        existing.push({ name: serviceName, port, url })
+      }
+    }
+
+    const result: WorktreeEntry[] = []
+    for (const [name, services] of worktreeMap) {
+      services.sort((a, b) => a.port - b.port)
+      result.push({ name, services })
+    }
+    result.sort((a, b) => a.name.localeCompare(b.name))
+
+    return NextResponse.json(result)
+  } catch (error) {
+    console.error('Failed to read host services:', error)
+    return NextResponse.json([])
+  }
+}

--- a/packages/404-app/app/not-found.tsx
+++ b/packages/404-app/app/not-found.tsx
@@ -180,10 +180,59 @@ export default function NotFound() {
   const anchorRefs = useRef<(HTMLAnchorElement | null)[]>([])
 
   useEffect(() => {
-    fetch('/api/worktrees')
-      .then(r => r.json())
-      .then((data: WorktreeEntry[]) => {
-        setWorktrees(data)
+    Promise.all([
+      fetch('/api/worktrees')
+        .then(r => r.json())
+        .catch(() => []) as Promise<WorktreeEntry[]>,
+      fetch('/api/host-services')
+        .then(r => r.json())
+        .catch(() => []) as Promise<WorktreeEntry[]>,
+    ])
+      .then(([dockerWorktrees, hostServices]) => {
+        // Merge docker worktrees and host services
+        const merged = new Map<string, ServiceEntry[]>()
+
+        // Add docker worktrees
+        for (const wt of dockerWorktrees) {
+          if (!merged.has(wt.name)) {
+            merged.set(wt.name, [])
+          }
+          const existing = merged.get(wt.name)!
+          for (const service of wt.services) {
+            const alreadyAdded = existing.some(
+              s => s.name === service.name && s.port === service.port
+            )
+            if (!alreadyAdded) {
+              existing.push(service)
+            }
+          }
+        }
+
+        // Add host services
+        for (const wt of hostServices) {
+          if (!merged.has(wt.name)) {
+            merged.set(wt.name, [])
+          }
+          const existing = merged.get(wt.name)!
+          for (const service of wt.services) {
+            const alreadyAdded = existing.some(
+              s => s.name === service.name && s.port === service.port
+            )
+            if (!alreadyAdded) {
+              existing.push(service)
+            }
+          }
+        }
+
+        // Convert map to array
+        const result: WorktreeEntry[] = []
+        for (const [name, services] of merged) {
+          services.sort((a, b) => a.port - b.port)
+          result.push({ name, services })
+        }
+        result.sort((a, b) => a.name.localeCompare(b.name))
+
+        setWorktrees(result)
         setLoading(false)
       })
       .catch(() => setLoading(false))

--- a/src/lib/traefik.test.ts
+++ b/src/lib/traefik.test.ts
@@ -148,6 +148,15 @@ describe('Traefik 404 handler', () => {
     expect(composeContent).not.toContain('docker ps')
     expect(composeContent).not.toContain('socat')
   })
+
+  test('404 handler mounts port registry directory', async () => {
+    await traefik.initTraefikFiles([3000])
+
+    const composeContent = await readFile(traefik.TRAEFIK_COMPOSE_FILE, 'utf-8')
+
+    expect(composeContent).toContain('/mnt/port-data')
+    expect(composeContent).toContain('PORT_REGISTRY_PATH')
+  })
 })
 
 describe('composeNeeds404HandlerUpdate', () => {

--- a/src/lib/traefik.ts
+++ b/src/lib/traefik.ts
@@ -128,7 +128,13 @@ async function updateTraefikComposeUnlocked(ports: number[]): Promise<void> {
         image: get404HandlerImage(),
         container_name: 'port-404-handler',
         restart: 'unless-stopped',
-        volumes: ['/var/run/docker.sock:/var/run/docker.sock:ro'],
+        volumes: [
+          '/var/run/docker.sock:/var/run/docker.sock:ro',
+          `${GLOBAL_PORT_DIR}:/mnt/port-data:ro`,
+        ],
+        environment: {
+          PORT_REGISTRY_PATH: '/mnt/port-data/registry.json',
+        },
         networks: [TRAEFIK_NETWORK],
       },
     },
@@ -316,7 +322,13 @@ export function generateTraefikCompose(): string {
         image: get404HandlerImage(),
         container_name: 'port-404-handler',
         restart: 'unless-stopped',
-        volumes: ['/var/run/docker.sock:/var/run/docker.sock:ro'],
+        volumes: [
+          '/var/run/docker.sock:/var/run/docker.sock:ro',
+          `${GLOBAL_PORT_DIR}:/mnt/port-data:ro`,
+        ],
+        environment: {
+          PORT_REGISTRY_PATH: '/mnt/port-data/registry.json',
+        },
         networks: [TRAEFIK_NETWORK],
       },
     },
@@ -387,19 +399,35 @@ export async function hasFileProvider(): Promise<boolean> {
  * - A service pointing to the port-404-handler container
  * - Middleware for error page handling (optional, router provides main fallback)
  *
+ * @param ports - Array of ports to create fallback routers for (in addition to web)
  * @returns Dynamic config YAML string for error pages
  */
-export function generate404ErrorPageConfig(): string {
+export function generate404ErrorPageConfig(ports: number[] = []): string {
+  const routers: Record<
+    string,
+    { rule: string; priority: number; service: string; entryPoints: string[] }
+  > = {
+    'port-404-fallback': {
+      rule: 'PathPrefix(`/`)',
+      priority: 1,
+      service: 'port-404-handler',
+      entryPoints: ['web'],
+    },
+  }
+
+  // Add fallback routers for each port entrypoint
+  for (const port of ports) {
+    routers[`port-404-fallback-${port}`] = {
+      rule: 'PathPrefix(`/`)',
+      priority: 1,
+      service: 'port-404-handler',
+      entryPoints: [`port${port}`],
+    }
+  }
+
   const config = {
     http: {
-      routers: {
-        'port-404-fallback': {
-          rule: 'PathPrefix(`/`)',
-          priority: 1,
-          service: 'port-404-handler',
-          entryPoints: ['web'],
-        },
-      },
+      routers,
       middlewares: {
         'error-pages': {
           errors: {


### PR DESCRIPTION
## Summary
- Add `/api/host-services` endpoint to read host services from the port registry
- Update 404 page to fetch and merge both Docker containers (`port up`) and host services (`port run`)
- Mount `~/.port` directory in 404 handler container to access the registry file
- Add `PORT_REGISTRY_PATH` environment variable to configure registry path
- Add test to verify registry mount in Traefik compose

Fixes #127

#### Test plan
- [x] Unit test added to verify registry mount in Traefik compose
- [x] Manual testing: Run `port run 3000 <command>` and verify service appears in 404 page
- [x] Verify 404 page still works for Docker containers (`port up`)
- [x] Verify graceful handling when registry file doesn't exist

Generated with [Devin](https://devin.ai)