### PR TITLE
Make port enter friendly in uninitialized repos

### DIFF
--- a/src/commands/enter.command.test.ts
+++ b/src/commands/enter.command.test.ts
@@ -8,6 +8,7 @@ const mocks = vi.hoisted(() => ({
   ensurePortRuntimeDir: vi.fn(),
   getTreesDir: vi.fn(),
   getComposeFile: vi.fn(),
+  configExists: vi.fn(),
   branchExists: vi.fn(),
   createWorktree: vi.fn(),
   remoteBranchExists: vi.fn(),
@@ -47,6 +48,7 @@ vi.mock('../lib/config.ts', () => ({
   ensurePortRuntimeDir: mocks.ensurePortRuntimeDir,
   getTreesDir: mocks.getTreesDir,
   getComposeFile: mocks.getComposeFile,
+  configExists: mocks.configExists,
 }))
 
 vi.mock('../lib/git.ts', () => ({
@@ -132,6 +134,7 @@ describe('enter typo confirmation', () => {
     mocks.loadConfigOrDefault.mockResolvedValue({ domain: 'port', compose: 'docker-compose.yml' })
     mocks.getTreesDir.mockReturnValue('/tmp')
     mocks.getComposeFile.mockReturnValue('docker-compose.yml')
+    mocks.configExists.mockReturnValue(true)
     mocks.worktreeExists.mockReturnValue(false)
     mocks.branchExists.mockResolvedValue(false)
     mocks.remoteBranchExists.mockResolvedValue(false)
@@ -348,6 +351,7 @@ describe('enter with shell hook eval file', () => {
     mocks.loadConfigOrDefault.mockResolvedValue({ domain: 'port', compose: 'docker-compose.yml' })
     mocks.getTreesDir.mockReturnValue('/tmp')
     mocks.getComposeFile.mockReturnValue('docker-compose.yml')
+    mocks.configExists.mockReturnValue(true)
     mocks.worktreeExists.mockReturnValue(true)
     mocks.getWorktreePath.mockReturnValue('/repo/.port/trees/feature-1')
     mocks.hookExists.mockResolvedValue(false)
@@ -410,5 +414,29 @@ describe('enter with shell hook eval file', () => {
     await enter('feature-1')
 
     expect(mocks.dim).toHaveBeenCalledWith(expect.stringContaining('port shell-hook'))
+    expect(mocks.dim).not.toHaveBeenCalledWith(expect.stringContaining('port init'))
+  })
+
+  test('suggests port init when Port is not initialized', async () => {
+    mocks.configExists.mockReturnValue(false)
+
+    await enter('feature-1')
+
+    expect(mocks.dim).toHaveBeenCalledWith(expect.stringContaining('port init'))
+    expect(mocks.dim).toHaveBeenCalledWith(expect.stringContaining('port shell-hook'))
+  })
+
+  test('stays quiet about override.yml when Port is not initialized', async () => {
+    mocks.configExists.mockReturnValue(false)
+
+    await enter('feature-1')
+
+    expect(mocks.dim).not.toHaveBeenCalledWith(expect.stringContaining('override.yml'))
+  })
+
+  test('warns about override.yml when Port is initialized', async () => {
+    await enter('feature-1')
+
+    expect(mocks.dim).toHaveBeenCalledWith(expect.stringContaining('override.yml'))
   })
 })

--- a/src/commands/enter.ts
+++ b/src/commands/enter.ts
@@ -5,6 +5,7 @@ import {
   getTreesDir,
   getComposeFile,
   ensurePortRuntimeDir,
+  configExists,
 } from '../lib/config.ts'
 import {
   branchExists,
@@ -52,6 +53,9 @@ export async function enter(branch: string): Promise<void> {
 
   // Load config (defaults when config file is absent)
   const config = await loadConfigOrDefault(repoRoot)
+
+  // Port works as a plain worktree manager when `port init` has not been run
+  const isInitialized = configExists(repoRoot)
 
   // Sanitize branch name
   const sanitized = sanitizeBranchName(branch)
@@ -189,8 +193,11 @@ export async function enter(branch: string): Promise<void> {
     await writeOverrideFile(worktreePath, parsedCompose, sanitized, config.domain, projectName)
     output.success('Generated .port/override.yml')
   } catch (error) {
-    // It's okay if compose parsing fails here - the file might not exist yet in the worktree
-    output.dim('Could not generate .port/override.yml (compose file may not exist yet)')
+    // It's okay if compose parsing fails here - the file might not exist yet in the
+    // worktree, and repositories without Port config may not use compose at all
+    if (isInitialized) {
+      output.dim('Could not generate .port/override.yml (compose file may not exist yet)')
+    }
   }
 
   // If running inside the shell hook, write eval commands to the sideband file
@@ -211,6 +218,11 @@ export async function enter(branch: string): Promise<void> {
   output.dim('  eval "$(port shell-hook bash)"   # in ~/.bashrc')
   output.dim('  eval "$(port shell-hook zsh)"    # in ~/.zshrc')
   output.dim('  port shell-hook fish | source    # in ~/.config/fish/config.fish')
+
+  if (!isInitialized) {
+    output.newline()
+    output.dim('Tip: Run "port init" to enable service routing, hooks and compose overrides.')
+  }
 }
 
 function getForwardedArgs(branch: string): string[] {


### PR DESCRIPTION
Closes #123

## Summary

`port enter` already worked without `port init` (`loadConfigOrDefault` + `ensurePortRuntimeDir` cover the missing config, and the `enter + up works without running port init first` e2e test proves it). Verified in a scratch repo with no `.port/config.jsonc`: the worktree is created and the command exits 0.

What was actually broken was the messaging: worktree-manager users, who have no compose file, got

```
Could not generate .port/override.yml (compose file may not exist yet)
```

and no pointer to `port init`. So this PR only touches output in `enter`:

```diff
+const isInitialized = configExists(repoRoot)
 } catch {
-  output.dim('Could not generate .port/override.yml ...')
+  if (isInitialized) output.dim('Could not generate .port/override.yml ...')
 }
+if (!isInitialized) output.dim('Tip: Run "port init" to enable service routing, hooks and compose overrides.')
```

Override generation, hooks and shell integration are unchanged, so a repo without config that *does* have a compose file still gets `.port/override.yml` (as `enter.test.ts` expects).

The branch was reset onto current `main`; the earlier `Cascade snapshot` commit on it carried unrelated WIP (`port run --background`, per-port Traefik 404 routers, a TUI `WorktreeRowStateIndicator` whose test imports `bun:test` and fails under vitest, `.beads/` files). That WIP is preserved on `devin/cascade-wip-backup` and left out of this PR.


Link to Devin session: https://app.devin.ai/sessions/86d9c5ba20e94692a9a4095cb4edfd87
Requested by: @jdtzmn